### PR TITLE
optimize the definition of props with a more proper way

### DIFF
--- a/components/button/index.native.tsx
+++ b/components/button/index.native.tsx
@@ -7,6 +7,8 @@ import {
   TouchableHighlight,
   TouchableHighlightProperties,
   View,
+  ViewStyle,
+  StyleProp,
 } from 'react-native';
 import { ButtonPropsType } from './PropsType';
 import buttonStyle from './style/index.native';
@@ -15,7 +17,7 @@ export interface ButtonProps
   extends ButtonPropsType,
     TouchableHighlightProperties {
   styles?: typeof buttonStyle;
-  activeStyle?: boolean;
+  activeStyle?: StyleProp<ViewStyle>;
   onClick?: (_?: any) => void;
 }
 

--- a/components/list/PropsType.tsx
+++ b/components/list/PropsType.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
 // export type ListType = JSX.Element
 export interface ListPropsType {
   renderHeader?: (() => React.ReactType) | string | JSX.Element;
@@ -15,7 +16,7 @@ export interface ListItemPropsType {
   extra?: ReactNode;
   arrow?: 'horizontal' | 'down' | 'up' | 'empty' | '';
   wrap?: boolean;
-  activeStyle?: React.CSSProperties;
+  activeStyle?: StyleProp<ViewStyle>;
   error?: boolean;
   platform?: 'android' | 'ios';
 }
@@ -23,5 +24,5 @@ export interface ListItemPropsType {
 export interface BriefProps {
   children?: ReactNode;
   wrap?: boolean;
-  style?: React.CSSProperties | {} | Array<{}>;
+  style?: StyleProp<ViewStyle>;
 }


### PR DESCRIPTION
In this PR, I mainly change ButtonProps#activeStyle from `boolean` to `StyleProp<ViewStyle>`
https://github.com/ant-design/ant-design-mobile-rn/blob/71147f08b612bb258b8aa23e77e9c67c730a82fd/components/button/index.native.tsx#L18
It is because when I run this button demo, 
https://github.com/ant-design/ant-design-mobile-rn/blob/22603c21f1ac2c6399aec76bce0e47defb830bfc/components/button/demo/basic.native.tsx#L32
TSLint warns me that
```
不能将类型“{ backgroundColor: string; }”分配给类型“boolean | undefined”。
```
It's confusing and kind of a mistake.
So I make this PR.

BTW, I correct a little other related code.