### PR TITLE
fix SwipeAction props type defination about left and right

### DIFF
--- a/components/swipe-action/index.tsx
+++ b/components/swipe-action/index.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { StyleProp, Text, TextStyle, View } from 'react-native';
 import Swipeout, { SwipeoutButtonProperties, SwipeoutProperties } from 'react-native-swipeout';
 
-export interface SwipeActionProps extends SwipeoutProperties {}
+export interface SwipeActionProps extends SwipeoutProperties {
+  left?: SwipeoutButtonProps[];
+  right?: SwipeoutButtonProps[];
+}
 export interface SwipeoutButtonProps extends SwipeoutButtonProperties {
   style?: StyleProp<TextStyle> & { backgroundColor: string };
 }


### PR DESCRIPTION
The default type defination of `SwipeAction` buttons is `?SwipeoutButtonProperties[]`, and there is no style property of SwipeoutButtonProperties.
So when I use literal object which has a style prop for right or left buttons, there will be an error: `Object literal may only specify known properties, and 'style' does not exist in type 'SwipeoutButtonProperties'`
Example:
```javascript
<SwipeAction
  autoClose
  style={{ backgroundColor: 'transparent' }}
  right={[
    {
      text: 'More',
      style: { backgroundColor: 'orange', color: 'white' }
    },
    {
      text: 'Delete',
      style: { backgroundColor: 'red', color: 'white' }
    }
  ]}
>
  <List.Item extra='extra content'>Simple example: left and right buttons</List.Item>
</SwipeAction>
```