### PR TITLE
fix: remove react native require cycle warning

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -19,7 +19,7 @@ const maxHeight = StyleSheet.create({
 
 export interface ModalProps
   extends ModalPropsType<TextStyle>,
-    WithThemeStyles<ModalStyle> {
+  WithThemeStyles<ModalStyle> {
   style?: StyleProp<ViewStyle>;
   bodyStyle?: StyleProp<ViewStyle>;
 }
@@ -32,16 +32,16 @@ class AntmModal extends React.Component<ModalProps, any> {
     style: {},
     bodyStyle: {},
     animationType: 'fade',
-    onClose() {},
+    onClose() { },
     footer: [],
     transparent: false,
     popup: false,
     animateAppear: true,
     operation: false,
   };
-  static alert = alert;
-  static operation = operation;
-  static prompt = prompt;
+  static alert: typeof alert;
+  static operation: typeof operation;
+  static prompt: typeof prompt;
 
   static contextTypes = {
     antLocale: PropTypes.object,

--- a/components/modal/index.tsx
+++ b/components/modal/index.tsx
@@ -1,3 +1,10 @@
 import Modal from './Modal';
+import alert from './alert';
+import prompt from './prompt';
+import operation from './operation';
+
+Modal.alert = alert;
+Modal.prompt = prompt;
+Modal.operation = operation;
 
 export default Modal;


### PR DESCRIPTION
fix #236 
set the `alert`,`prompt`,`operation` value of component `Modal` in `components/modal/index.tsx` instead of `components/modal/Modal.tsx` to avoid require cycle.
