### PR TITLE
fix search-bar icon size

### DIFF
--- a/components/locale-provider/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/locale-provider/__tests__/__snapshots__/demo.test.js.snap
@@ -695,11 +695,10 @@ exports[`renders ./components/locale-provider/demo/basic.tsx correctly 1`] = `
                 },
                 Object {
                   "color": "#cccccc",
-                  "height": 15,
+                  "fontSize": 15,
                   "left": 16,
                   "position": "absolute",
                   "top": 14.5,
-                  "width": 15,
                 },
               ]
             }

--- a/components/search-bar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/search-bar/__tests__/__snapshots__/demo.test.js.snap
@@ -75,11 +75,10 @@ exports[`renders ./components/search-bar/demo/basic.tsx correctly 1`] = `
           },
           Object {
             "color": "#cccccc",
-            "height": 15,
+            "fontSize": 15,
             "left": 16,
             "position": "absolute",
             "top": 14.5,
-            "width": 15,
           },
         ]
       }
@@ -154,11 +153,10 @@ exports[`renders ./components/search-bar/demo/basic.tsx correctly 1`] = `
           },
           Object {
             "color": "#cccccc",
-            "height": 15,
+            "fontSize": 15,
             "left": 16,
             "position": "absolute",
             "top": 14.5,
-            "width": 15,
           },
         ]
       }

--- a/components/search-bar/style/index.tsx
+++ b/components/search-bar/style/index.tsx
@@ -59,7 +59,6 @@ export default (theme: Theme) =>
       position: 'absolute',
       left: theme.h_spacing_md + 8,
       top: (theme.search_bar_height - theme.icon_size_xxs) / 2,
-      width: theme.icon_size_xxs,
-      height: theme.icon_size_xxs,
+      fontSize: theme.icon_size_xxs,
     },
   });

--- a/components/tab-bar/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/tab-bar/__tests__/__snapshots__/demo.test.js.snap
@@ -124,11 +124,10 @@ exports[`renders ./components/tab-bar/demo/basic.tsx correctly 1`] = `
                   },
                   Object {
                     "color": "#cccccc",
-                    "height": 15,
+                    "fontSize": 15,
                     "left": 16,
                     "position": "absolute",
                     "top": 14.5,
-                    "width": 15,
                   },
                 ]
               }
@@ -262,11 +261,10 @@ exports[`renders ./components/tab-bar/demo/basic.tsx correctly 1`] = `
                   },
                   Object {
                     "color": "#cccccc",
-                    "height": 15,
+                    "fontSize": 15,
                     "left": 16,
                     "position": "absolute",
                     "top": 14.5,
-                    "width": 15,
                   },
                 ]
               }
@@ -398,11 +396,10 @@ exports[`renders ./components/tab-bar/demo/basic.tsx correctly 1`] = `
                   },
                   Object {
                     "color": "#cccccc",
-                    "height": 15,
+                    "fontSize": 15,
                     "left": 16,
                     "position": "absolute",
                     "top": 14.5,
-                    "width": 15,
                   },
                 ]
               }
@@ -534,11 +531,10 @@ exports[`renders ./components/tab-bar/demo/basic.tsx correctly 1`] = `
                   },
                   Object {
                     "color": "#cccccc",
-                    "height": 15,
+                    "fontSize": 15,
                     "left": 16,
                     "position": "absolute",
                     "top": 14.5,
-                    "width": 15,
                   },
                 ]
               }


### PR DESCRIPTION
`SearchBar` icon size doesn't fit well, default size of the icon is `md` but height may be `xxs` and the component `Icon` doesn't use `width` or `height` to set icon size but `fontSize`.