### PR TITLE
use call fn to invoke scollView's scrollTo

### DIFF
--- a/components/tabs/Tabs.tsx
+++ b/components/tabs/Tabs.tsx
@@ -196,7 +196,7 @@ export class Tabs extends React.PureComponent<TabsProps, StateType> {
       if (this.scrollView && this.scrollView._component) {
         const { scrollTo } = this.scrollView._component;
         // tslint:disable-next-line:no-unused-expression
-        scrollTo && scrollTo({ x: offset, animated });
+        scrollTo && scrollTo.call(this.scrollView._component, { x: offset, animated });
       }
     }
   };


### PR DESCRIPTION

Fix [Type error when using Tabs (react-native: 0.59.x) #403](https://github.com/ant-design/ant-design-mobile-rn/issues/403)
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
