### PR TITLE
SegmentedControl comonent selected segment  text bug in android

### DIFF
--- a/components/segmented-control/PropsType.tsx
+++ b/components/segmented-control/PropsType.tsx
@@ -5,4 +5,5 @@ export interface SegmentedControlPropsType {
   values?: string[];
   onChange?: (e: any) => void;
   onValueChange?: (value: string) => void;
+  selectedSegTextColor?: string  //for android platform
 }

--- a/components/segmented-control/PropsType.tsx
+++ b/components/segmented-control/PropsType.tsx
@@ -5,5 +5,5 @@ export interface SegmentedControlPropsType {
   values?: string[];
   onChange?: (e: any) => void;
   onValueChange?: (value: string) => void;
-  selectedSegTextColor?: string  //for android platform
+  selectedSegTextColor?: string;  //for android platform
 }

--- a/components/segmented-control/PropsType.tsx
+++ b/components/segmented-control/PropsType.tsx
@@ -5,5 +5,5 @@ export interface SegmentedControlPropsType {
   values?: string[];
   onChange?: (e: any) => void;
   onValueChange?: (value: string) => void;
-  selectedSegTextColor?: string;  //for android platform
+  selectedTextColor?: string;  //for android platform
 }

--- a/components/segmented-control/demo/basic.tsx
+++ b/components/segmented-control/demo/basic.tsx
@@ -23,6 +23,7 @@ export default class BasicTagExample extends React.Component<any, any> {
           values={['Segment1', 'Segment2', 'Segment3']}
           tintColor={'#ff0000'}
           style={{ height: 40, width: 280 }}
+          selectedSegTextColor={'black'}
         />
         <WhiteSpace size="lg" />
         <Text>SelectedIndex</Text>

--- a/components/segmented-control/demo/basic.tsx
+++ b/components/segmented-control/demo/basic.tsx
@@ -23,7 +23,6 @@ export default class BasicTagExample extends React.Component<any, any> {
           values={['Segment1', 'Segment2', 'Segment3']}
           tintColor={'#ff0000'}
           style={{ height: 40, width: 280 }}
-          selectedSegTextColor={'black'}
         />
         <WhiteSpace size="lg" />
         <Text>SelectedIndex</Text>

--- a/components/segmented-control/segmented.android.tsx
+++ b/components/segmented-control/segmented.android.tsx
@@ -47,7 +47,7 @@ export default class SegmentedControl extends React.Component<
     onChange() {},
     onValueChange() {},
     style: {},
-    selectedSegTextColor: '#fff',
+    selectedTextColor: '#fff',
   };
 
   constructor(props: SegmentControlProps) {
@@ -83,7 +83,7 @@ export default class SegmentedControl extends React.Component<
   }
 
   render() {
-    const { style, disabled, values = [], selectedSegTextColor } = this.props;
+    const { style, disabled, values = [], selectedTextColor } = this.props;
     let { tintColor } = this.props;
     return (
       <WithTheme styles={this.props.styles} themeStyles={AndroidStyles}>
@@ -129,7 +129,7 @@ export default class SegmentedControl extends React.Component<
                   // tslint:disable-next-line:jsx-no-multiline-js
                   style={[
                     styles.itemText,
-                    { color: idx === selectedIndex ? selectedSegTextColor : tintColor },
+                    { color: idx === selectedIndex ? selectedTextColor : tintColor },
                   ]}
                 >
                   {value}

--- a/components/segmented-control/segmented.android.tsx
+++ b/components/segmented-control/segmented.android.tsx
@@ -128,7 +128,7 @@ export default class SegmentedControl extends React.Component<
                   // tslint:disable-next-line:jsx-no-multiline-js
                   style={[
                     styles.itemText,
-                    { color: idx === selectedIndex ? style.color == undefined ? '#fff' : style.color : tintColor },
+                    { color: idx === selectedIndex ? style.color === undefined ? '#fff' : style.color : tintColor },
                   ]}
                 >
                   {value}

--- a/components/segmented-control/segmented.android.tsx
+++ b/components/segmented-control/segmented.android.tsx
@@ -128,7 +128,7 @@ export default class SegmentedControl extends React.Component<
                   // tslint:disable-next-line:jsx-no-multiline-js
                   style={[
                     styles.itemText,
-                    { color: idx === selectedIndex ? '#fff' : tintColor },
+                    { color: idx === selectedIndex ? style.color == undefined ? '#fff' : style.color : tintColor },
                   ]}
                 >
                   {value}

--- a/components/segmented-control/segmented.android.tsx
+++ b/components/segmented-control/segmented.android.tsx
@@ -47,6 +47,7 @@ export default class SegmentedControl extends React.Component<
     onChange() {},
     onValueChange() {},
     style: {},
+    selectedSegTextColor: '#fff',
   };
 
   constructor(props: SegmentControlProps) {
@@ -82,7 +83,7 @@ export default class SegmentedControl extends React.Component<
   }
 
   render() {
-    const { style, disabled, values = [] } = this.props;
+    const { style, disabled, values = [], selectedSegTextColor } = this.props;
     let { tintColor } = this.props;
     return (
       <WithTheme styles={this.props.styles} themeStyles={AndroidStyles}>
@@ -128,7 +129,7 @@ export default class SegmentedControl extends React.Component<
                   // tslint:disable-next-line:jsx-no-multiline-js
                   style={[
                     styles.itemText,
-                    { color: idx === selectedIndex ? style.color === undefined ? '#fff' : style.color : tintColor },
+                    { color: idx === selectedIndex ? selectedSegTextColor : tintColor },
                   ]}
                 >
                   {value}


### PR DESCRIPTION
# Summary
<p>&nbsp;&nbsp;The SegmentedControl component has a bug in Android because the selected segment text color is forced to be written as "#fff". When tintColor is set to "#fff", the selected segment text is invisible. The modified code can be used to set the current active text color via the style attribute. If not set, the default is "#fff". 
</p>
<p>&nbsp;&nbsp;SegmentedControl组件在安卓的情况下出现bug，原因是被选中的segment text颜色被强制写死成"#fff",在tintColor被设置为"#fff"的时候，被选中的segment文本看不见。修改过后的代码可以通过style属性来设置当前活跃文本颜色，如果没有设置的话默认为"#fff"。</p>

# Steps To Reproduce
<p>ant-design-mobile-rn: 2.3.3</p>
<p>device: android phone</p>
<p>
   import the SegmentedControl from ant-design-mobile-rn, and set the tintColor to “#fff”
</p>

![pr](https://user-images.githubusercontent.com/14856783/58326618-f2158400-7e5f-11e9-87b7-051ea0869a0b.png)

# Changelog
<p>[Android] [Fixed] fix the selected segment bug in android</p>
<h1>Test Plan</h1>

- [ done] Edit the demo of this componet,  set the "selectedSegTextColor" props to 'black',  check the commit does take effects in android simulator
```html
        <Text>TintColor and Style</Text>
        <SegmentedControl
          values={['Segment1', 'Segment2', 'Segment3']}
          tintColor={'#ff0000'}
          style={{ height: 40, width: 280 }}
          selectedSegTextColor={'black'}
        />
```
![image](https://user-images.githubusercontent.com/14856783/58408809-2deb5c00-80a1-11e9-930f-ea266c82d7cb.png)

- [done]   npm run test -- components/segmented-control/__tests__/index.test.js ,  the commit pass the test
![image](https://user-images.githubusercontent.com/14856783/58408877-69862600-80a1-11e9-9e2f-3c49fecfd1a1.png)
