### PR TITLE
Modal动画销毁前停止动画

### DIFF
--- a/components/modal/ModalView.tsx
+++ b/components/modal/ModalView.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Animated, Dimensions, Easing, StyleProp, StyleSheet, TouchableWithoutFeedback, View, ViewStyle } from 'react-native';
+import {
+  Animated,
+  Dimensions,
+  Easing,
+  StyleProp,
+  StyleSheet,
+  TouchableWithoutFeedback,
+  View,
+  ViewStyle,
+} from 'react-native';
 import Portal from '../portal';
 
 const styles = StyleSheet.create({
@@ -91,6 +100,9 @@ export default class RCModal extends React.Component<IModalPropTypes, any> {
     if (prevProps.visible !== props.visible) {
       this.animateDialog(props.visible);
     }
+  }
+  componentWillUnmount() {
+    this.stopDialogAnim();
   }
   animateMask = (visible: boolean) => {
     this.stopMaskAnim();


### PR DESCRIPTION

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
> 有一些非我这边的改动导致的ts类型错误
```
antd-tools run compile
components\grid\index.tsx(91,33): error TS2345: Argument of type 'DataItem | undefined' is not assignable to parameter of type 'DataItem'.
  Type 'undefined' is not assignable to type 'DataItem'.
components\image-picker\demo\basic.tsx(54,9): error TS2345: Argument of type '{ 'title': string; 'message': string; }' is not assignable to parameter of type 'Rationale'.
  Property 'buttonPositive' is missing in type '{ 'title': string; 'message': string; }' but required in type 'Rationale'.
```
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
> 防止组件销毁后执行动画完成回调导致setState一个不存在的组件

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.
> I Have no idea how to write this bug to test its case 
> i cause by its unmount too fast which modal animation have not been finish and call its callback to setState.
> i have test it in my local repo to directly change lib `js` file

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
