### PR TITLE
Grid新的一行不满columnNum时，如果自定义了itemStyle，用来填充columnNum的item样式会和正常的item不一样的问题

### DIFF
--- a/components/grid/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/demo.test.js.snap
@@ -828,6 +828,7 @@ exports[`renders ./components/grid/demo/basic.tsx correctly 1`] = `
                     "borderRightWidth": 0,
                     "height": 187.5,
                   },
+                  Object {},
                 ],
               ]
             }
@@ -846,6 +847,7 @@ exports[`renders ./components/grid/demo/basic.tsx correctly 1`] = `
                     "borderRightWidth": 0,
                     "height": 187.5,
                   },
+                  Object {},
                 ],
               ]
             }
@@ -864,6 +866,7 @@ exports[`renders ./components/grid/demo/basic.tsx correctly 1`] = `
                     "borderRightWidth": 0,
                     "height": 187.5,
                   },
+                  Object {},
                 ],
               ]
             }

--- a/components/grid/index.tsx
+++ b/components/grid/index.tsx
@@ -95,7 +95,7 @@ export default class Grid extends React.Component<GridProps, any> {
                 rowArr.push(
                   <Flex.Item
                     key={j}
-                    style={[styles.grayBorderBox, flexItemStyle]}
+                    style={[styles.grayBorderBox, flexItemStyle, customItemStyle]}
                   />,
                 );
               }


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

Grid新的一行不满columnNum时，如果自定义了itemStyle，用来填充columnNum的item样式会和正常的item不一样的问题
比如自定义了itemStyle的height，该行被填充的item的height拉伸，导致和别的满columnNum的行不一致