### PR TITLE
Deprecated onTintColor substituted by trackColor

### DIFF
--- a/components/switch/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/switch/__tests__/__snapshots__/demo.test.js.snap
@@ -90,7 +90,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
             onChange={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
-            onTintColor="#4dd865"
+            trackColor="#4dd865"
             style={
               Object {
                 "height": 31,
@@ -175,7 +175,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
             onChange={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
-            onTintColor="#4dd865"
+            trackColor="#4dd865"
             style={
               Object {
                 "height": 31,
@@ -252,7 +252,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
                 ]
               }
             >
-              onChange event, switch status: 
+              onChange event, switch status:
             </Text>
             <Text
               numberOfLines={1}
@@ -274,7 +274,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
             onChange={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
-            onTintColor="#4dd865"
+            trackColor="#4dd865"
             style={
               Object {
                 "height": 31,
@@ -359,7 +359,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
             onChange={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
-            onTintColor="#4dd865"
+            trackColor="#4dd865"
             style={
               Object {
                 "height": 31,
@@ -444,7 +444,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
             onChange={[Function]}
             onResponderTerminationRequest={[Function]}
             onStartShouldSetResponder={[Function]}
-            onTintColor="red"
+            trackColor="red"
             style={
               Object {
                 "height": 31,

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -18,7 +18,7 @@ const AntmSwitch = (props: AntmSwitchProps) => {
       onValueChange={onChange}
       value={checked}
       disabled={disabled}
-      onTintColor={color}
+      trackColor={color}
     />
   );
 };


### PR DESCRIPTION
As of RN 0.57 `onTintColor` is deprecated and needs to be changed to `trackColor`, see https://facebook.github.io/react-native/docs/switch#trackcolor