### PR TITLE
fixs: https://github.com/ant-design/ant-design-mobile-rn/issues/722

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Dimensions, LayoutChangeEvent, StyleProp, StyleSheet, Text, TextStyle, TouchableHighlight, TouchableWithoutFeedback, View, ViewStyle } from 'react-native';
+import { Dimensions, LayoutChangeEvent, StyleProp, StyleSheet, Text, TextStyle, TouchableHighlight, TouchableWithoutFeedback, View, ViewStyle, KeyboardAvoidingView, Platform } from 'react-native';
 import { WithTheme, WithThemeStyles } from '../style';
 import { getComponentLocale } from '../_util/getLocale';
 import alert from './alert';
@@ -176,20 +176,22 @@ class AntmModal extends React.Component<ModalProps, any> {
                   onClose={onClose}
                   animationType={animType}
                   wrapStyle={transparent ? styles.wrap : undefined}
-                  style={[styles.innerContainer, style]}
+                  style={styles.wrap}
                   visible={visible}
                   onAnimationEnd={onAnimationEnd}
                   animateAppear={animateAppear}
                   maskClosable={maskClosable}
                 >
-                  <View style={maxHeight} ref={this.saveRoot}>
-                    {title ? (
-                      <Text style={[styles.header]}>{title}</Text>
-                    ) : null}
-                    <View style={[styles.body, bodyStyle]}>{children}</View>
-                    {footerDom}
-                    {closableDom}
-                  </View>
+                  <KeyboardAvoidingView behavior="padding" enabled={Platform.OS==="ios"}>
+                    <View style={[styles.innerContainer,style]} ref={this.saveRoot}>
+                      {title ? (
+                        <Text style={[styles.header]}>{title}</Text>
+                      ) : null}
+                      <View style={[styles.body, bodyStyle]}>{children}</View>
+                      {footerDom}
+                      {closableDom}
+                    </View>
+                  </KeyboardAvoidingView>
                 </RCModal>
               </View>
             );

--- a/components/modal/PromptContainer.tsx
+++ b/components/modal/PromptContainer.tsx
@@ -1,7 +1,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { BackHandler, KeyboardAvoidingView, Text, TextInput, TextStyle, View } from 'react-native';
+import { BackHandler, Text, TextInput, TextStyle, View } from 'react-native';
 import { WithTheme, WithThemeStyles } from '../style';
 import { getComponentLocale } from '../_util/getLocale';
 import zh_CN from './locale/zh_CN';
@@ -166,7 +166,6 @@ export default class PropmptContainer extends React.Component<
               footer={footer}
               onAnimationEnd={onAnimationEnd}
             >
-              <KeyboardAvoidingView behavior="padding">
                 {message ? <Text style={styles.message}>{message}</Text> : null}
                 <View style={styles.inputGroup}>
                   {type !== 'secure-text' && (
@@ -199,7 +198,6 @@ export default class PropmptContainer extends React.Component<
                     </View>
                   )}
                 </View>
-              </KeyboardAvoidingView>
             </Modal>
           );
         }}

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -30,8 +30,10 @@ export default (theme: Theme) =>
       zIndex: theme.modal_zindex,
     },
     wrap: {
+      flex: 1,
       justifyContent: 'center',
       alignItems: 'center',
+      backgroundColor: 'transparent',
     },
     popupContainer: {},
     popupSlideUp: {
@@ -46,6 +48,7 @@ export default (theme: Theme) =>
       width: 286,
       paddingTop: theme.v_spacing_xl,
       overflow: 'hidden',
+      backgroundColor: theme.fill_base,
     },
     // fix android borderRadius
     footer: {
@@ -77,7 +80,7 @@ export default (theme: Theme) =>
     },
     closeWrap: {
       position: 'absolute',
-      top: 0,
+      top: theme.v_spacing_xl,
       left: theme.h_spacing_lg,
     },
     close: {


### PR DESCRIPTION
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:


  * [X] Make sure that you add at least one unit test for the bug which you had fixed.

# 代码说明
修改`Modal.tsx`样式，将`innerContainer`样式放在`<RCModal>`内，并由`KeyboardAvoidingView`包裹，而`<RCModal>`高度撑满并设置为透明，

以达到在`ios`中键盘呼出时(`Android`系统自带)，`innerContainer`图层有空间向上顶露出`TextInput`

⚠️注意：仅测试通过本地用例