### PR TITLE
remove Result defaultProps

### DIFF
--- a/components/result/index.tsx
+++ b/components/result/index.tsx
@@ -13,9 +13,6 @@ export interface ResultNativeProps
 }
 
 export default class Result extends React.Component<ResultNativeProps, any> {
-  static defaultProps = {
-    buttonType: '',
-  };
 
   render() {
     const {


### PR DESCRIPTION
修复Result组件没有指定buttonType时的错误
`TypeError: undefined is not an object (evaluating '_reactNative.StyleSheet.flatten(activeStyle ? activeStyle : _styles[type + 'Highlight']).backgroundColor')
`