### PR TITLE
fix: Arrow type error

### DIFF
--- a/components/list/style/index.tsx
+++ b/components/list/style/index.tsx
@@ -13,8 +13,8 @@ export interface ListStyle {
   Extra: TextStyle;
   Brief: ViewStyle;
   BriefText: TextStyle;
-  Arrow: ViewStyle;
-  ArrowV: ViewStyle;
+  Arrow: TextStyle;
+  ArrowV: TextStyle;
   multipleLine: ViewStyle;
   multipleThumb: ImageStyle;
   column: ViewStyle;


### PR DESCRIPTION
不能将类型“{ fontSize: number; }”分配给类型“ViewStyle”

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
