### PR TITLE
feat: configurable toast

### DIFF
--- a/components/switch/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/switch/__tests__/__snapshots__/demo.test.js.snap
@@ -81,7 +81,12 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
           </View>
           <Switch
             disabled={false}
-            onTintColor="#4dd865"
+            trackColor={
+              Object {
+                "false": "",
+                "true": "#4dd865",
+              }
+            }
             value={true}
           />
         </View>
@@ -151,7 +156,12 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
           </View>
           <Switch
             disabled={false}
-            onTintColor="#4dd865"
+            trackColor={
+              Object {
+                "false": "",
+                "true": "#4dd865",
+              }
+            }
             value={false}
           />
         </View>
@@ -235,8 +245,13 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
           </View>
           <Switch
             disabled={false}
-            onTintColor="#4dd865"
             onValueChange={[Function]}
+            trackColor={
+              Object {
+                "false": "",
+                "true": "#4dd865",
+              }
+            }
             value={false}
           />
         </View>
@@ -306,7 +321,12 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
           </View>
           <Switch
             disabled={true}
-            onTintColor="#4dd865"
+            trackColor={
+              Object {
+                "false": "",
+                "true": "#4dd865",
+              }
+            }
             value={false}
           />
         </View>
@@ -376,7 +396,12 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
           </View>
           <Switch
             disabled={false}
-            onTintColor="red"
+            trackColor={
+              Object {
+                "false": "",
+                "true": "red",
+              }
+            }
             value={true}
           />
         </View>

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -20,7 +20,7 @@ const AntmSwitch = (props: AntmSwitchProps) => {
       disabled={disabled}
       trackColor={{
         true: color,
-        false: color,
+        false: '',
       }}
     />
   );

--- a/components/switch/index.tsx
+++ b/components/switch/index.tsx
@@ -18,7 +18,10 @@ const AntmSwitch = (props: AntmSwitchProps) => {
       onValueChange={onChange}
       value={checked}
       disabled={disabled}
-      onTintColor={color}
+      trackColor={{
+        true: color,
+        false: color,
+      }}
     />
   );
 };

--- a/components/toast/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/toast/__tests__/__snapshots__/demo.test.js.snap
@@ -9,11 +9,191 @@ exports[`renders ./components/toast/demo/basic.tsx correctly 1`] = `
         "marginRight": 15,
       },
       Object {
-        "marginTop": 80,
+        "marginTop": 20,
       },
     ]
   }
 >
+  <View>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#ffffff",
+          "borderTopColor": "#dddddd",
+          "borderTopWidth": 0.5,
+        }
+      }
+    >
+      <
+        activeOpacity={1}
+        delayLongPress={500}
+        onLongPress={[Function]}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "paddingLeft": 15,
+              },
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "borderBottomColor": "#dddddd",
+                  "borderBottomWidth": 0.5,
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "minHeight": 44,
+                  "paddingRight": 15,
+                  "paddingVertical": 6,
+                },
+                false,
+                false,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "flex": 1,
+                    "flexDirection": "column",
+                  },
+                ]
+              }
+            >
+              <Text
+                numberOfLines={1}
+                style={
+                  Array [
+                    Object {
+                      "color": "#000000",
+                      "fontSize": 17,
+                      "textAlignVertical": "center",
+                    },
+                  ]
+                }
+              >
+                Enable Mask
+              </Text>
+            </View>
+            <Switch
+              disabled={false}
+              onValueChange={[Function]}
+              trackColor={
+                Object {
+                  "false": "",
+                  "true": "#4dd865",
+                }
+              }
+              value={true}
+            />
+          </View>
+        </View>
+      </>
+      <
+        activeOpacity={1}
+        delayLongPress={500}
+        onLongPress={[Function]}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "flexGrow": 1,
+                "paddingLeft": 15,
+              },
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "borderBottomColor": "#dddddd",
+                  "borderBottomWidth": 0.5,
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "minHeight": 44,
+                  "paddingRight": 15,
+                  "paddingVertical": 6,
+                },
+                false,
+                false,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "flex": 1,
+                    "flexDirection": "column",
+                  },
+                ]
+              }
+            >
+              <Text
+                numberOfLines={1}
+                style={
+                  Array [
+                    Object {
+                      "color": "#000000",
+                      "fontSize": 17,
+                      "textAlignVertical": "center",
+                    },
+                  ]
+                }
+              >
+                Enable Stack
+              </Text>
+            </View>
+            <Switch
+              disabled={false}
+              onValueChange={[Function]}
+              trackColor={
+                Object {
+                  "false": "",
+                  "true": "#4dd865",
+                }
+              }
+              value={true}
+            />
+          </View>
+        </View>
+      </>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "#ffffff",
+              "borderBottomColor": "#dddddd",
+              "borderBottomWidth": 0.5,
+              "bottom": 0,
+              "height": 1,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
   <View
     style={
       Array [
@@ -80,6 +260,75 @@ exports[`renders ./components/toast/demo/basic.tsx correctly 1`] = `
         }
       >
         Without mask
+      </Text>
+    </View>
+  </>
+  <View
+    style={
+      Array [
+        Object {
+          "height": 9,
+        },
+        undefined,
+      ]
+    }
+  />
+  <
+    activeOpacity={0.4}
+    disabled={false}
+    onHideUnderlay={[Function]}
+    onPress={[Function]}
+    onPressIn={[Function]}
+    onPressOut={[Function]}
+    onShowUnderlay={[Function]}
+    pressIn={false}
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "borderRadius": 5,
+          "borderWidth": 1,
+          "justifyContent": "center",
+        },
+        Object {
+          "height": 47,
+          "paddingLeft": 15,
+          "paddingRight": 15,
+        },
+        Object {
+          "backgroundColor": "#ffffff",
+          "borderColor": "#dddddd",
+        },
+        false,
+        false,
+        undefined,
+        undefined,
+      ]
+    }
+    underlayColor="#dddddd"
+  >
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+        }
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "fontSize": 18,
+            },
+            Object {
+              "color": "#000000",
+            },
+            false,
+            false,
+          ]
+        }
+      >
+        Stackable toast
       </Text>
     </View>
   </>
@@ -493,19 +742,9 @@ exports[`renders ./components/toast/demo/basic.tsx correctly 1`] = `
           ]
         }
       >
-        Toast width duration = 0
+        Toast with duration = 0
       </Text>
     </View>
   </>
-  <View
-    style={
-      Array [
-        Object {
-          "height": 9,
-        },
-        undefined,
-      ]
-    }
-  />
 </View>
 `;

--- a/components/toast/demo/basic.tsx
+++ b/components/toast/demo/basic.tsx
@@ -1,13 +1,28 @@
 /* tslint:disable:no-console */
 import React from 'react';
 import { DeviceEventEmitter } from 'react-native';
-import { Button, Portal, Toast, WhiteSpace, WingBlank } from '../../';
+import { Button, List, Portal, Switch, Toast, WhiteSpace, WingBlank } from '../../';
 
-function showToast() {
+function showToastStack() {
   // multiple toast
-  Toast.info('This is a toast tips 1 !!!', 4);
-  Toast.info('This is a toast tips 2 !!!', 3);
-  Toast.info('This is a toast tips 3 !!!', 1);
+  Toast.fail({
+    content: 'This is a toast tips 1 !!!',
+    duration: 3,
+  });
+  Toast.success({
+    content: 'This is a toast tips 2 !!!',
+    duration: 2,
+  });
+  Toast.info({
+    content: 'This is a toast tips 3 !!!',
+    duration: 1,
+  });
+}
+
+function infoToast() {
+  Toast.info({
+    content: 'Text toast',
+  });
 }
 
 function successToast() {
@@ -15,7 +30,10 @@ function successToast() {
 }
 
 function showToastNoMask() {
-  Toast.info('Toast without mask !!!', 1, undefined, false);
+  Toast.info({
+    content: 'Toast without mask',
+    mask: false,
+  });
 }
 
 function failToast() {
@@ -27,13 +45,20 @@ function offline() {
 }
 
 function loadingToast() {
-  Toast.loading('Loading...', 1, () => {
-    console.log('Load complete !!!');
-  });
+  Toast.loading({
+    content: 'Loading...',
+    duration: 1,
+    onClose: () => console.log('Load complete !!!'),
+  })
 }
 
 export default class ToastExample extends React.Component<any, any> {
   timer: any;
+
+  state = {
+    enableMask: Toast.getConfig().mask,
+    enableStack: Toast.getConfig().stackable,
+  }
 
   componentWillUnmount() {
     (DeviceEventEmitter as any).removeAllListeners('navigatorBack');
@@ -44,7 +69,10 @@ export default class ToastExample extends React.Component<any, any> {
   }
 
   alwaysShowToast = () => {
-    const key = Toast.info('A toast width duration = 0 !!!', 0);
+    const key = Toast.info({
+      content: 'Toast with duration = 0, removed by timer',
+      duration: 0,
+    });
     this.timer = setTimeout(() => {
       Portal.remove(key);
     }, 5000);
@@ -52,11 +80,11 @@ export default class ToastExample extends React.Component<any, any> {
 
   render() {
     return (
-      <WingBlank style={{ marginTop: 80 }}>
+      <WingBlank style={{ marginTop: 20 }}>
         <WhiteSpace />
         <Button onPress={showToastNoMask}>Without mask</Button>
         <WhiteSpace />
-        <Button onPress={showToast}>Text toast</Button>
+        <Button onPress={infoToast}>Text toast</Button>
         <WhiteSpace />
         <Button onPress={successToast}>Success toast</Button>
         <WhiteSpace />
@@ -66,8 +94,38 @@ export default class ToastExample extends React.Component<any, any> {
         <WhiteSpace />
         <Button onPress={loadingToast}>Loading toast</Button>
         <WhiteSpace />
-        <Button onPress={this.alwaysShowToast}>Toast width duration = 0</Button>
+        <Button onPress={this.alwaysShowToast}>Toast with duration = 0</Button>
         <WhiteSpace />
+        <Button onPress={showToastStack}>Stackable toast</Button>
+        <WhiteSpace />
+        <List style={{ marginTop: 20 }}>
+          <List.Item
+            extra={
+              <Switch
+                checked={this.state.enableMask}
+                onChange={mask => {
+                  Toast.config({ mask });
+                  this.setState({ enableMask: Toast.getConfig().mask });
+                }}
+              />
+            }
+          >
+            Enable Mask
+          </List.Item>
+          <List.Item
+            extra={
+              <Switch
+                checked={this.state.enableStack}
+                onChange={stackable => {
+                  Toast.config({ stackable });
+                  this.setState({ enableStack: Toast.getConfig().stackable });
+                }}
+              />
+            }
+          >
+            Enable Stack
+          </List.Item>
+        </List>
       </WingBlank>
     );
   }

--- a/components/toast/demo/basic.tsx
+++ b/components/toast/demo/basic.tsx
@@ -1,21 +1,24 @@
 /* tslint:disable:no-console */
 import React from 'react';
 import { DeviceEventEmitter } from 'react-native';
-import { Button, List, Portal, Switch, Toast, WhiteSpace, WingBlank } from '../../';
+import { Button, List, Switch, Toast, WhiteSpace, WingBlank } from '../../';
 
 function showToastStack() {
   // multiple toast
   Toast.fail({
     content: 'This is a toast tips 1 !!!',
     duration: 3,
+    stackable: true,
   });
   Toast.success({
     content: 'This is a toast tips 2 !!!',
     duration: 2,
+    stackable: true,
   });
   Toast.info({
     content: 'This is a toast tips 3 !!!',
     duration: 1,
+    stackable: true,
   });
 }
 
@@ -74,31 +77,14 @@ export default class ToastExample extends React.Component<any, any> {
       duration: 0,
     });
     this.timer = setTimeout(() => {
-      Portal.remove(key);
+      Toast.remove(key);
     }, 5000);
   };
 
   render() {
     return (
       <WingBlank style={{ marginTop: 20 }}>
-        <WhiteSpace />
-        <Button onPress={showToastNoMask}>Without mask</Button>
-        <WhiteSpace />
-        <Button onPress={infoToast}>Text toast</Button>
-        <WhiteSpace />
-        <Button onPress={successToast}>Success toast</Button>
-        <WhiteSpace />
-        <Button onPress={failToast}>Failed toast</Button>
-        <WhiteSpace />
-        <Button onPress={offline}>Network failure toast</Button>
-        <WhiteSpace />
-        <Button onPress={loadingToast}>Loading toast</Button>
-        <WhiteSpace />
-        <Button onPress={this.alwaysShowToast}>Toast with duration = 0</Button>
-        <WhiteSpace />
-        <Button onPress={showToastStack}>Stackable toast</Button>
-        <WhiteSpace />
-        <List style={{ marginTop: 20 }}>
+        <List>
           <List.Item
             extra={
               <Switch
@@ -126,6 +112,22 @@ export default class ToastExample extends React.Component<any, any> {
             Enable Stack
           </List.Item>
         </List>
+        <WhiteSpace />
+        <Button onPress={showToastNoMask}>Without mask</Button>
+        <WhiteSpace />
+        <Button onPress={showToastStack}>Stackable toast</Button>
+        <WhiteSpace />
+        <Button onPress={infoToast}>Text toast</Button>
+        <WhiteSpace />
+        <Button onPress={successToast}>Success toast</Button>
+        <WhiteSpace />
+        <Button onPress={failToast}>Failed toast</Button>
+        <WhiteSpace />
+        <Button onPress={offline}>Network failure toast</Button>
+        <WhiteSpace />
+        <Button onPress={loadingToast}>Loading toast</Button>
+        <WhiteSpace />
+        <Button onPress={this.alwaysShowToast}>Toast with duration = 0</Button>
       </WingBlank>
     );
   }

--- a/components/toast/index.en-US.md
+++ b/components/toast/index.en-US.md
@@ -7,33 +7,36 @@ title: Toast
 A lightweight feedback or tips, used to display content that does not interrupt user operations. Suitable for page transitions, data interaction and other scenes.
 
 ### Rules
-- Only one Toast is allowed at a time.
-- Toast with Icon, 4-6 words is recommended.; Toast without Icon, the number of words should not exceed 14.
+- Toast with Icon, 4-6 words is recommended; Toast without Icon, the number of words should not exceed 14.
 
 ## API
 
-- `Toast.success(content, duration, onClose, mask)`
-- `Toast.fail(content, duration, onClose, mask)`
-- `Toast.info(content, duration, onClose, mask)`
-- `Toast.loading(content, duration, onClose, mask)`
-- `Toast.offline(content, duration, onClose, mask)`
+- `Toast.success(props)`
+- `Toast.fail(props)`
+- `Toast.info(props)`
+- `Toast.loading(props)`
+- `Toast.offline(props)`
 
-The component provide several static methods：
+Props has these fields:
 
-| Properties | Descrition                                                                           | Type                    | Default |
-| ---------- | ------------------------------------------------------------------------------------ | ----------------------- | ------- |
-| content    | Toast content                                                                        | React.Element or String | -       |
-| duration   | Delay time to close, which units is second                                           | number                  | 3       |
-| onClose    | A callback function Triggered when the Toast is closed                               | Function                | -       |
-| mask       | Whether to show a transparent mask, which will prevent touch event of the whole page | Boolean                 | true    |
+| Properties | Descrition                                                                           | Type                |  Required  | Default |
+| ---------- | ------------------------------------------------------------------------------------ | ----------------------- | ------- | ------- |
+| content    | Toast content                                                                        | String | Yes | -       |
+| duration   | Delay time to close, which units is second                                           | number                  |  No  | 3       |
+| onClose    | A callback function Triggered when the Toast is closed                               | Function                |  No  | -       |
+| mask       | Whether to show a transparent mask, which will prevent touch event of the whole page | Boolean                 |  No  | true    |
+| stackable |  Whether to allow toast overlay       | Boolean  |  No   |   true  |
 
 > **Notice：** OnClose is invalid and Toast does not hide, If set duration = 0, toast will not auto hide, you have to manually do it.
 
-
-> 3.0.0 began to remove the previous `Toast.hide` method, `Toast.xxx` now returns a `key` to manually close the prompt using `Portal.remove(key)`
-
 ```js
-  import { Portal, Toast } from '@ant-design/react-native'
-  const key Toast.loading('messsage')
-  Portal.remove(key)
+import { Toast } from '@ant-design/react-native';
+
+const key = Toast.loading('message');
+Toast.remove(key);
 ```
+
+### Configuration
+
+- `Toast.getConfig()` - get current config
+- `Toast.config(props)` - customize default value for NOT required parameters

--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -2,34 +2,92 @@ import React from 'react';
 import Portal from '../portal';
 import ToastContainer from './ToastContainer';
 
+interface IToastConfigurable {
+  duration?: number;
+  onClose?: () => void,
+  mask?: boolean;
+  stackable?: boolean;
+}
+
+interface IToastProps extends IToastConfigurable {
+  content: string;
+}
+
+const defaultConfig: IToastConfigurable = {
+  duration: 2,
+  onClose: () => {},
+  mask: true,
+  stackable: true,
+}
+
+let defaultProps = {
+  ...defaultConfig,
+}
+
+const toastKeyMap: { [key: number]: 1 } = {};
+
 function notice(
-  content: string,
+  content: string | IToastProps,
   type: string,
-  duration = 2,
-  onClose: (() => void) | undefined,
-  mask = true,
+  duration = defaultProps.duration,
+  onClose = defaultProps.onClose,
+  mask = defaultProps.mask,
 ) {
+  let props = {
+    ...defaultProps,
+    content: content as string,
+    type,
+    duration,
+    onClose,
+    mask,
+  }
+
+  if (typeof content !== 'string') {
+    props = {
+      ...props,
+      ...content,
+    }
+  }
+
+  if (!props.stackable) {
+    Object.keys(toastKeyMap).forEach((_key) => Portal.remove(Number.parseInt(_key, 10)));
+  }
+
   const key = Portal.add(
     <ToastContainer
-      content={content}
-      duration={duration}
-      onClose={onClose}
-      type={type}
-      mask={mask}
-      onAnimationEnd={() => Portal.remove(key)}
+      content={props.content}
+      duration={props.duration}
+      onClose={props.onClose}
+      type={props.type}
+      mask={props.mask}
+      onAnimationEnd={() => {
+        Portal.remove(key);
+        delete toastKeyMap[key];
+      }}
     />,
   );
+  toastKeyMap[key] = 1;
   return key;
 }
 
 export default {
   SHORT: 3,
   LONG: 8,
-  show(content: string, duration?: number, mask?: boolean) {
+  defaultConfig,
+  getConfig: () => {
+    return {...defaultProps};
+  },
+  config(props: IToastConfigurable) {
+    defaultProps = {
+      ...defaultProps,
+      ...props,
+    }
+  },
+  show(content: string | IToastProps, duration?: number, mask?: boolean) {
     return notice(content, 'info', duration, () => {}, mask);
   },
   info(
-    content: string,
+    content: string | IToastProps,
     duration?: number,
     onClose?: () => void,
     mask?: boolean,
@@ -37,7 +95,7 @@ export default {
     return notice(content, 'info', duration, onClose, mask);
   },
   success(
-    content: string,
+    content: string | IToastProps,
     duration?: number,
     onClose?: () => void,
     mask?: boolean,
@@ -45,7 +103,7 @@ export default {
     return notice(content, 'success', duration, onClose, mask);
   },
   fail(
-    content: string,
+    content: string | IToastProps,
     duration?: number,
     onClose?: () => void,
     mask?: boolean,
@@ -53,7 +111,7 @@ export default {
     return notice(content, 'fail', duration, onClose, mask);
   },
   offline(
-    content: string,
+    content: string | IToastProps,
     duration?: number,
     onClose?: () => void,
     mask?: boolean,
@@ -61,7 +119,7 @@ export default {
     return notice(content, 'offline', duration, onClose, mask);
   },
   loading(
-    content: string,
+    content: string | IToastProps,
     duration?: number,
     onClose?: () => void,
     mask?: boolean,

--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -26,6 +26,10 @@ let defaultProps = {
 
 const toastKeyMap: { [key: number]: 1 } = {};
 
+function removeAll() {
+  Object.keys(toastKeyMap).forEach((_key) => Portal.remove(Number.parseInt(_key, 10)));
+}
+
 function notice(
   content: string | IToastProps,
   type: string,
@@ -50,7 +54,7 @@ function notice(
   }
 
   if (!props.stackable) {
-    Object.keys(toastKeyMap).forEach((_key) => Portal.remove(Number.parseInt(_key, 10)));
+    removeAll();
   }
 
   const key = Portal.add(
@@ -126,4 +130,8 @@ export default {
   ) {
     return notice(content, 'loading', duration, onClose, mask);
   },
+  remove(key: number) {
+    Portal.remove(key);
+  },
+  removeAll,
 };

--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -89,9 +89,19 @@ export default {
       ...props,
     }
   },
+  /**
+   * @deprecated
+   */
   show(content: string | IToastProps, duration?: number, mask?: boolean) {
     return notice(content, 'info', duration, () => {}, mask);
   },
+  /**
+   *
+   * @param content
+   * @deprecated @param duration
+   * @deprecated @param onClose
+   * @deprecated @param mask
+   */
   info(
     content: string | IToastProps,
     duration?: number,
@@ -100,6 +110,13 @@ export default {
   ) {
     return notice(content, 'info', duration, onClose, mask);
   },
+  /**
+   *
+   * @param content
+   * @deprecated @param duration
+   * @deprecated @param onClose
+   * @deprecated @param mask
+   */
   success(
     content: string | IToastProps,
     duration?: number,
@@ -108,6 +125,13 @@ export default {
   ) {
     return notice(content, 'success', duration, onClose, mask);
   },
+  /**
+   *
+   * @param content
+   * @deprecated @param duration
+   * @deprecated @param onClose
+   * @deprecated @param mask
+   */
   fail(
     content: string | IToastProps,
     duration?: number,
@@ -116,6 +140,13 @@ export default {
   ) {
     return notice(content, 'fail', duration, onClose, mask);
   },
+  /**
+   *
+   * @param content
+   * @deprecated @param duration
+   * @deprecated @param onClose
+   * @deprecated @param mask
+   */
   offline(
     content: string | IToastProps,
     duration?: number,
@@ -124,6 +155,13 @@ export default {
   ) {
     return notice(content, 'offline', duration, onClose, mask);
   },
+  /**
+   *
+   * @param content
+   * @deprecated @param duration
+   * @deprecated @param onClose
+   * @deprecated @param mask
+   */
   loading(
     content: string | IToastProps,
     duration?: number,

--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -13,8 +13,10 @@ interface IToastProps extends IToastConfigurable {
   content: string;
 }
 
+const SHORT = 3;
+
 const defaultConfig: IToastConfigurable = {
-  duration: 2,
+  duration: SHORT,
   onClose: () => {},
   mask: true,
   stackable: true,
@@ -75,7 +77,7 @@ function notice(
 }
 
 export default {
-  SHORT: 3,
+  SHORT,
   LONG: 8,
   defaultConfig,
   getConfig: () => {

--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -90,85 +90,85 @@ export default {
     }
   },
   /**
-   * @deprecated
+   * @deprecated use Toast.info instead
    */
-  show(content: string | IToastProps, duration?: number, mask?: boolean) {
-    return notice(content, 'info', duration, () => {}, mask);
+  show(props: string | IToastProps, duration?: number, mask?: boolean) {
+    return notice(props, 'info', duration, () => {}, mask);
   },
   /**
    *
-   * @param content
-   * @deprecated @param duration
-   * @deprecated @param onClose
-   * @deprecated @param mask
+   * @param props: toast props
+   * @deprecated duration: use props instead
+   * @deprecated onClose: use props instead
+   * @deprecated mask: use props instead
    */
   info(
-    content: string | IToastProps,
+    props: string | IToastProps,
     duration?: number,
     onClose?: () => void,
     mask?: boolean,
   ) {
-    return notice(content, 'info', duration, onClose, mask);
+    return notice(props, 'info', duration, onClose, mask);
   },
   /**
    *
-   * @param content
-   * @deprecated @param duration
-   * @deprecated @param onClose
-   * @deprecated @param mask
+   * @param props: toast props
+   * @deprecated duration: use props instead
+   * @deprecated onClose: use props instead
+   * @deprecated mask: use props instead
    */
   success(
-    content: string | IToastProps,
+    props: string | IToastProps,
     duration?: number,
     onClose?: () => void,
     mask?: boolean,
   ) {
-    return notice(content, 'success', duration, onClose, mask);
+    return notice(props, 'success', duration, onClose, mask);
   },
   /**
    *
-   * @param content
-   * @deprecated @param duration
-   * @deprecated @param onClose
-   * @deprecated @param mask
+   * @param props: toast props
+   * @deprecated duration: use props instead
+   * @deprecated onClose: use props instead
+   * @deprecated mask: use props instead
    */
   fail(
-    content: string | IToastProps,
+    props: string | IToastProps,
     duration?: number,
     onClose?: () => void,
     mask?: boolean,
   ) {
-    return notice(content, 'fail', duration, onClose, mask);
+    return notice(props, 'fail', duration, onClose, mask);
   },
   /**
    *
-   * @param content
-   * @deprecated @param duration
-   * @deprecated @param onClose
-   * @deprecated @param mask
+   * @param props: toast props
+   * @deprecated duration: use props instead
+   * @deprecated onClose: use props instead
+   * @deprecated mask: use props instead
    */
   offline(
-    content: string | IToastProps,
+    props: string | IToastProps,
     duration?: number,
     onClose?: () => void,
     mask?: boolean,
   ) {
-    return notice(content, 'offline', duration, onClose, mask);
+    return notice(props, 'offline', duration, onClose, mask);
   },
   /**
    *
-   * @param content
-   * @deprecated @param duration
-   * @deprecated @param onClose
-   * @deprecated @param mask
+   * @param props: toast props
+   * @deprecated duration: use props instead
+   * @deprecated onClose: use props instead
+   * @deprecated mask: use props instead
    */
   loading(
-    content: string | IToastProps,
+    props: string | IToastProps,
     duration?: number,
     onClose?: () => void,
     mask?: boolean,
   ) {
-    return notice(content, 'loading', duration, onClose, mask);
+    return notice(props, 'loading', duration, onClose, mask);
   },
   remove(key: number) {
     Portal.remove(key);

--- a/components/toast/index.zh-CN.md
+++ b/components/toast/index.zh-CN.md
@@ -8,33 +8,36 @@ subtitle: 轻提示
 一种轻量级反馈/提示，可以用来显示不会打断用户操作的内容，适合用于页面转场、数据交互的等场景中。
 
 ### 规则
-- 一次只显示一个 toast。
 - 有 Icon 的 Toast，字数为 4-6 个；没有 Icon 的 Toast，字数不宜超过 14 个。
 
 ## API
 
-- `Toast.success(content, duration, onClose, mask)`
-- `Toast.fail(content, duration, onClose, mask)`
-- `Toast.info(content, duration, onClose, mask)`
-- `Toast.loading(content, duration, onClose, mask)`
-- `Toast.offline(content, duration, onClose, mask)`
+- `Toast.success(props)`
+- `Toast.fail(props)`
+- `Toast.info(props)`
+- `Toast.loading(props)`
+- `Toast.offline(props)`
 
-组件提供了五个静态方法，参数如下：
+Props 参数如下：
 
-| 属性     | 说明                           | 类型                    | 默认值 |
-| -------- | ------------------------------ | ----------------------- | ------ |
-| content  | 提示内容                       | React.Element or String | 无     |
-| duration | 自动关闭的延时，单位秒         | number                  | 3      |
-| onClose  | 关闭后回调                     | Function                | 无     |
-| mask     | 是否显示透明蒙层，防止触摸穿透 | Boolean                 | true   |
+|    属性    | 说明                           | 类型      | 必填 | 默认值 |
+| --------  | ------------------------------ | -------- | --- | ------ |
+| content   | 提示内容                        | String   | 是   |  -     |
+| duration  | 自动关闭的延时，单位秒            | number   |  否  |  3       |
+| onClose   | 关闭后回调                      | Function  |  否  | - |
+| mask      | 是否显示透明蒙层，防止触摸穿透     | Boolean   |  否   |   true  |
+| stackable | 是否允许叠加显示                 | Boolean  |  否   |   true  |
 
-> **注：**  duration = 0 时，onClose 无效，toast 不会消失；隐藏 toast 需要手动调用 hide
-
-
-> 3.0.0 开始移除了 之前的`Toast.hide`方法，`Toast.xxx` 现在返回一个`key`可以使用`Portal.remove(key)`手动关闭提示
+> **注：**  duration = 0 时，onClose 无效，toast 不会消失，隐藏 toast 需要手动调用 remove
 
 ```js
-  import { Portal, Toast } from '@ant-design/react-native'
-  const key Toast.loading('messsage')
-  Portal.remove(key)
+import { Toast } from '@ant-design/react-native';
+
+const key = Toast.loading('message');
+Toast.remove(key);
 ```
+
+### 自定义配置
+
+- `Toast.getConfig()` - 获取当前配置
+- `Toast.config(props)` - 配置非必填项的默认值


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [x] Update API docs for the component.
  * [x] Update/Add demo to demonstrate new feature.
  * [x] Update TypeScript definition for the component.
  * [x] Add unit tests for the feature.

### 新增功能
https://github.com/ant-design/ant-design-mobile-rn/issues/899
- defaultConfig，Toast 默认参数
- config 方法，用于自定义 Toast 的默认参数，建议在 App 启动后调用
- getConfig 方法，用于获取当前配置
- content 参数支持传入对象，向后兼容的同时，支持新的参数
  - stackable: 开启时，这条 Toast 会叠加在之前的 Toast 上；关闭时，弹出这条 Toast 前会清空其它 Toast。默认开启，建议开发者在生产环境下关闭，保证更好的用户体验。
- remove 方法，同 Portal.remove，对外隐藏 Portal 概念
- removeAll 方法，清空当前所有 Toast

### Bug Fix
- 修复文档中“一次只允许一个 Toast”这个不正确的描述
- 将文档中未提及的 show API 标记为 deprecated
- 修复文档中对于 hide 的相关描述
- 修复文档中 duration 默认值是 3s，但代码中是 2s 的问题
- Switch 使用 trackColor，消除 RN 的警告⚠️