### PR TITLE
fix: toast jsdoc

### DIFF
--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -98,9 +98,6 @@ export default {
   /**
    *
    * @param props: toast props
-   * @deprecated duration: use props instead
-   * @deprecated onClose: use props instead
-   * @deprecated mask: use props instead
    */
   info(
     props: string | IToastProps,
@@ -113,9 +110,6 @@ export default {
   /**
    *
    * @param props: toast props
-   * @deprecated duration: use props instead
-   * @deprecated onClose: use props instead
-   * @deprecated mask: use props instead
    */
   success(
     props: string | IToastProps,
@@ -128,9 +122,6 @@ export default {
   /**
    *
    * @param props: toast props
-   * @deprecated duration: use props instead
-   * @deprecated onClose: use props instead
-   * @deprecated mask: use props instead
    */
   fail(
     props: string | IToastProps,
@@ -143,9 +134,6 @@ export default {
   /**
    *
    * @param props: toast props
-   * @deprecated duration: use props instead
-   * @deprecated onClose: use props instead
-   * @deprecated mask: use props instead
    */
   offline(
     props: string | IToastProps,
@@ -158,9 +146,6 @@ export default {
   /**
    *
    * @param props: toast props
-   * @deprecated duration: use props instead
-   * @deprecated onClose: use props instead
-   * @deprecated mask: use props instead
    */
   loading(
     props: string | IToastProps,


### PR DESCRIPTION
去掉了错误的 `@depreacted` 使用，原来的写法会导致整个方法被标记为废弃。

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [ ] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [ ] Rebase before creating a PR to keep commit history clear.
* [ ] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
