### PR TITLE
Dev environment and rn-kitchen-sink fixes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "prepublish": "antd-tools run guard",
     "prepare": "antd-tools run guard",
     "prepublishOnly": "antd-tools run guard",
+    "postinstall" : "pod install --project-directory=./rn-kitchen-sink/ios",
     "test": "jest --config .jest.config.js",
     "test:all": "./scripts/test-all.sh",
     "compile": "cross-env BABEL_ENV=dist antd-tools run compile",

--- a/rn-kitchen-sink/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/rn-kitchen-sink/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
-</adaptive-icon>

--- a/rn-kitchen-sink/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/rn-kitchen-sink/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
-</adaptive-icon>


### PR DESCRIPTION
## Summary
In checking out the development environment and starting dev on `form`, I came across an improvement and an error. I made a couple of minor additions/fixes.

## Change 1
During kitchen sink Android build (from react-native cli), an error was thrown: resource drawable/ic_launcher_background (aka com.kitchensink:drawable/ic_launcher_background) not found.

I attempted ./gradlew clean and problem was not on my end. If adaptive icon configuration was done through android studio previously and a file was excluded (or external) to the project, that could be the source of the error.

I rolled this back so kitchen sink android will build properly. I deleted the folder: ant-design-mobile-rn/rn-kitchen-sink/android/app/src/main/res/mipmap-anydpi-v26/

This is a very minor fix, not much is affected.

Currently, both antd icons with the android and ios kitchen sink are displayed properly after the build.



## Change 2
Added "postinstall" property in package.json to perform a pod install for the rn-kitchen-sink/ios project.

This addition helps in the required pod install for new dependencies that need it and decreases dev hassle when testing new deps, etc.

## Other
I also noticed that we support React 17+ , but there is a conflict with the react version in `ant-design/icons-react-native`...

> Could not resolve dependency: npm ERR! peer react@"16.x" from @ant-design/icons-react-native@2.3.1

...which upon further investigation yielded multiple other conflicts with peer dependencies in larger libraries... so I gave up and just did `npm install --force`.

Other than that, setting up the development environment with rather smoothly. We can always update the dev docs once more contributors hop on... I don't think it is necessary at the moment.

Tag: @1uokun 

