### PR TITLE
fix: 'Types of property 'content' are incompatible.' in Toast and add demo

### DIFF
--- a/components/toast/ToastContainer.tsx
+++ b/components/toast/ToastContainer.tsx
@@ -5,7 +5,7 @@ import { WithTheme, WithThemeStyles } from '../style'
 import ToastStyles, { ToastStyle } from './style/index'
 
 export interface ToastProps extends WithThemeStyles<ToastStyle> {
-  content: string
+  content: string | React.ReactNode
   duration?: number
   onClose?: () => void
   mask?: boolean

--- a/components/toast/demo/basic.tsx
+++ b/components/toast/demo/basic.tsx
@@ -1,6 +1,6 @@
 /* tslint:disable:no-console */
 import React from 'react'
-import { DeviceEventEmitter } from 'react-native'
+import { DeviceEventEmitter, Text } from 'react-native'
 import { Button, List, Switch, Toast, WhiteSpace, WingBlank } from '../../'
 
 function showToastStack() {
@@ -73,6 +73,19 @@ function alwaysShowToastLoading() {
   }, 3000)
 }
 
+function showCustomViewToast() {
+  Toast.info(
+    { content: <Text style={{ color: 'red' }}>Toast Custom View</Text> },
+    2,
+  )
+  setTimeout(() => {
+    Toast.success(
+      { content: <Text style={{ color: 'red' }}>Toast Custom View</Text> },
+      2,
+    )
+  }, 2500)
+}
+
 export default class ToastExample extends React.Component<any, any> {
   timer: any
 
@@ -140,6 +153,8 @@ export default class ToastExample extends React.Component<any, any> {
         <Button onPress={alwaysShowToastLoading}>
           Toast.loading with duration = 0
         </Button>
+        <WhiteSpace />
+        <Button onPress={showCustomViewToast}>Toast with custom view</Button>
       </WingBlank>
     )
   }

--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -10,7 +10,7 @@ interface IToastConfigurable {
 }
 
 interface IToastProps extends IToastConfigurable {
-  content: string | React.ReactNode;
+  content: string | React.ReactNode
 }
 
 const SHORT = 3
@@ -48,7 +48,7 @@ function notice(
 ) {
   let props = {
     ...defaultProps,
-    content: content as string,
+    content: content as string | React.ReactNode,
     type,
     duration,
     onClose,


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

fix: 'Types of property 'content' are incompatible.' in Toast and add demo.

caused by this PR. [https://github.com/ant-design/ant-design-mobile-rn/pull/1160](https://github.com/ant-design/ant-design-mobile-rn/pull/1160)

Add test case for custom view in Toast.
![image](https://user-images.githubusercontent.com/1309744/140876236-e1ad3760-7c30-44c6-837e-615a111dcbff.png)



