### PR TITLE
fix: picker continer style

### DIFF
--- a/components/picker/style/index.tsx
+++ b/components/picker/style/index.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, TextStyle, ViewStyle } from 'react-native'
 
 export interface PickerStyle {
   modal: ViewStyle
+  container: ViewStyle
   header: ViewStyle
   headerItem: ViewStyle
   actionText: TextStyle
@@ -17,8 +18,10 @@ export default () =>
       flexDirection: 'column',
       justifyContent: 'flex-end',
     },
+    container:{
+      flexGrow:0.5,
+    },
     header: {
-      flexGrow: 1,
       height: 44,
       alignItems: 'center',
       flexDirection: 'row',


### PR DESCRIPTION
# fix: picker continer style

make up for missing styles: `picker/Popup.tsx`
https://github.com/ant-design/ant-design-mobile-rn/blob/master/components/picker/Popup.tsx#L36