### PR TITLE
fix: add libraries required for version 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ English | [简体中文](./README.zh-CN.md)
 
 A configurable Mobile UI specification and React-based implementation.
 
-> If you only care about the style you may give [[Tanjun]](https://github.com/bang88/Tanjun) a try. 
+> If you only care about the style you may give [[Tanjun]](https://github.com/bang88/Tanjun) a try.
 
 ## Features
 
@@ -47,7 +47,7 @@ yarn
 
 # start ios
 cd rn-kitchen-sink/ios && pod install
-yarn ios 
+yarn ios
 
 # start android
 yarn android
@@ -71,13 +71,13 @@ yarn add @ant-design/react-native
 ### Installing peer dependencies
 
 ```bash
-npm install @react-native-community/cameraroll @react-native-picker/picker @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler
+npm install @react-native-community/cameraroll @react-native-picker/picker @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler classnames rc-util
 ```
 
 or
 
 ```bash
-yarn add @react-native-community/cameraroll @react-native-picker/picker @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler
+yarn add @react-native-community/cameraroll @react-native-picker/picker @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler classnames rc-util
 ```
 
 > You need go to ios folder and run `pod install` (auto linking)，Android will handle it by itself.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,13 +69,13 @@ yarn add @ant-design/react-native
 ### 安装peer依赖
 
 ```bash
-npm install @react-native-community/cameraroll @react-native-picker/picker @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler
+npm install @react-native-community/cameraroll @react-native-picker/picker @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler classnames rc-util
 ```
 
 or
 
 ```bash
-yarn add @react-native-community/cameraroll @react-native-picker/picker @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler
+yarn add @react-native-community/cameraroll @react-native-picker/picker @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler classnames rc-util
 ```
 
 > 安装完依赖后需要到 iOS 目录 `pod install`(auto linking)，Android 不需要手动处理


### PR DESCRIPTION
Error: Unable to resolve module classnames from /Users/jerry/Awesome/node_modules/@ant-design/react-native/lib/tag/index.js: classnames could not be found within the project or in these directories:
  node_modules/@ant-design/react-native/node_modules

Error: Unable to resolve module rc-util/lib/hooks/useMergedState from /Users/jerry/Awesome/node_modules/@ant-design/react-native/lib/checkbox/Checkbox.js: rc-util/lib/hooks/useMergedState could not be found within the project or in these directories:
  node_modules/@ant-design/react-native/node_modules

按照文档安装依赖库，缺`classnames`跟`rc-util`运行不起来

```
System:
    OS: macOS 12.3.1
    CPU: (10) arm64 Apple M1 Max
    Memory: 14.87 GB / 64.00 GB
    Shell: 5.8 - /bin/zsh
  Binaries:
    Node: 16.13.0 - /usr/local/bin/node
    Yarn: 1.22.10 - /usr/local/bin/yarn
    npm: 8.5.0 - /usr/local/bin/npm
    Watchman: 4.9.0 - /usr/local/bin/watchman
  Managers:
    CocoaPods: 1.11.2 - /usr/local/bin/pod
  SDKs:
    iOS SDK:
      Platforms: DriverKit 21.4, iOS 15.4, macOS 12.3, tvOS 15.4, watchOS 8.5
    Android SDK:
      API Levels: 23, 25, 29, 30, 31
      Build Tools: 23.0.1, 27.0.3, 28.0.2, 28.0.3, 29.0.2, 29.0.3, 30.0.0, 30.0.0, 30.0.0, 30.0.1, 30.0.2, 30.0.3, 31.0.0, 31.0.0, 32.0.0, 32.0.0, 33.0.0, 33.0.0
      System Images: android-24 | ARM 64 v8a, android-30 | Google Play ARM 64 v8a, android-31 | ARM 64 v8a, android-31 | Google APIs ARM 64 v8a, android-31 | Google Play ARM 64 v8a, android-32 | Google APIs ARM 64 v8a, android-32 | Google Play ARM 64 v8a
      Android NDK: Not Found
  IDEs:
    Android Studio: Bumblebee 2021.1.1 Patch 3 Bumblebee 2021.1.1 Patch 3
    Xcode: 13.3.1/13E500a - /usr/bin/xcodebuild
  Languages:
    Java: 1.8.0_251 - /usr/bin/javac
    Python: Not Found
  npmPackages:
    @react-native-community/cli: Not Found
    react: 17.0.2 => 17.0.2 
    react-native: 0.68.0 => 0.68.0 
    react-native-macos: Not Found
  npmGlobalPackages:
    *react-native*: Not Found
```