### PR TITLE
docs: update the ActionSheet's docs

### DIFF
--- a/components/action-sheet/index.en-US.md
+++ b/components/action-sheet/index.en-US.md
@@ -19,7 +19,9 @@ Properties | Descrition | Type | Default
 ----|-----|------|------
 | options       | ActionSheet's options | Object |  -  |
 | callback       | Callback for selected item   | (index:number):void |  -  |
+
 Display a action sheet. The `options` object must contain one or more of:
+
 Properties | Descrition | Type | Default
 ----|-----|------|------
 | options       | a list of button titles (required) | Array or String |  -  |
@@ -29,13 +31,17 @@ Properties | Descrition | Type | Default
 | message       | a message to show below the title  | String or React.element |  -  |
 
 ### ActionSheet.showShareActionSheetWithOptions(options, failureCallback?, successCallback?)
+
 `React-Native Only, react-native@version >= 0.39`
+
 Properties | Descrition | Type | Default
 ----|-----|------|------
 | options       | ShareActionSheet's options | Object |  -  |
 | failureCallback       | Callback for share failed（`iOS Only`, See [react-native/share](https://github.com/facebook/react-native/blob/master/Libraries/Share/Share.js#L80) ） | (error):void |  -  |
 | successCallback       | Callback for share successed（`iOS Only`, See [react-native/share](https://github.com/facebook/react-native/blob/master/Libraries/Share/Share.js#L80) ） | (completed:Boolean, activityType?:String):void |  -  |
+
 Display a shareable action sheet. The `options` object must contain one or more of:
+
 Properties | Descrition | Type | Default
 ----|-----|------|------
 | message       | a message to share | String |  -  |

--- a/components/action-sheet/index.en-US.md
+++ b/components/action-sheet/index.en-US.md
@@ -14,30 +14,34 @@ The modal box pops up from the bottom, providing more than two actions related t
 
 
 ## API
-
-#### static showActionSheetWithOptions(options: Object, callback: Function)
-
+### ActionSheet.showActionSheetWithOptions(options, callback)
+Properties | Descrition | Type | Default
+----|-----|------|------
+| options       | ActionSheet's options | Object |  -  |
+| callback       | Callback for selected item   | (index:number):void |  -  |
 Display a action sheet. The `options` object must contain one or more of:
+Properties | Descrition | Type | Default
+----|-----|------|------
+| options       | a list of button titles (required) | Array or String |  -  |
+| cancelButtonIndex       | index of cancel button in `options`  | Number |  -  |
+| destructiveButtonIndex       | index of destructive button in `options`  | Number |  -  |
+| title       | a title to show above the action sheet  | String |  -  |
+| message       | a message to show below the title  | String or React.element |  -  |
 
-- options (array of strings) - a list of button titles (required)
-- cancelButtonIndex (int) - index of cancel button in `options`
-- destructiveButtonIndex (int) - index of destructive button in `options`
-- title (string) - a title to show above the action sheet
-- message (string/React.element) - a message to show below the title
+### ActionSheet.showShareActionSheetWithOptions(options, failureCallback?, successCallback?)
+`React-Native Only, react-native@version >= 0.39`
+Properties | Descrition | Type | Default
+----|-----|------|------
+| options       | ShareActionSheet's options | Object |  -  |
+| failureCallback       | Callback for share failed（`iOS Only`, See [react-native/share](https://github.com/facebook/react-native/blob/master/Libraries/Share/Share.js#L80) ） | (error):void |  -  |
+| successCallback       | Callback for share successed（`iOS Only`, See [react-native/share](https://github.com/facebook/react-native/blob/master/Libraries/Share/Share.js#L80) ） | (completed:Boolean, activityType?:String):void |  -  |
+Display a shareable action sheet. The `options` object must contain one or more of:
+Properties | Descrition | Type | Default
+----|-----|------|------
+| message       | a message to share | String |  -  |
+| title       | title of the message  | String |  -  |
+| url       | an URL to share `iOS Only`  | String |  -  |
+| excludedActivityTypes       | the activities to exclude from the ShareActionSheet `iOS Only`  | Array |  -  |
 
-#### static showShareActionSheetWithOptions(options: Object, failureCallback: Function, successCallback: Function)
-
-`React-Native only, react-native@version >= 0.39`
-
-Display shareable action sheet.
-
-- **options:**
-  - message(`string`): a message to share
-  - title(`string`): title of the message
-  - url(`string`): an URL to share `iOS only`
-  - excludedActivityTypes(`array`): the activities to exclude from the ActionSheet `iOS only`
-- **Callback**: (`iOS only`, see [react-native/share](https://github.com/facebook/react-native/blob/master/Libraries/Share/Share.js#L80))
-  - failureCallback(error): callback is called if share failed;
-  - successCallback(completed, method): callback is called if share successed;
-
-#### static close() - (android only) programmatically close.
+### ActionSheet.close()
+Close the action sheet.`Android Only`

--- a/components/action-sheet/index.zh-CN.md
+++ b/components/action-sheet/index.zh-CN.md
@@ -15,30 +15,36 @@ subtitle: 动作面板
 
 
 ## API
+### ActionSheet.showActionSheetWithOptions(options, callback)
+属性 | 说明 | 类型 | 默认值
+----|-----|------|------
+| options       | 动作面板配置 | Object |  无  |
+| callback       | 操作成功后调用  | (index:number):void |  无  |
+显示动作面板，`options`对象必须包含以下的一个或者多个：
+属性 | 说明 | 类型 | 默认值
+----|-----|------|------
+| options       | 按钮标题列表 (必须) | Array 或 String |  无  |
+| cancelButtonIndex       | 按钮列表中取消按钮的索引位置  | Number |  无  |
+| destructiveButtonIndex       | 按钮列表中破坏性按钮（一般为删除）的索引位置  | Number |  无  |
+| title       | 顶部标题  | String |  无  |
+| message       | 顶部标题下的简要消息  | String 或 React.element |  无  |
 
-#### static showActionSheetWithOptions(options: Object, callback: Function)
 
-显示 action sheet，`options`对象必须包含以下的一个或者多个：
+### ActionSheet.showShareActionSheetWithOptions(options, failureCallback?, successCallback?)
+`仅支持React-Native,且react-native@version >= 0.39`
+属性 | 说明 | 类型 | 默认值
+----|-----|------|------
+| options       | 动作面板配置 | Object |  无  |
+| failureCallback       | 分享失败调用（`仅支持iOS`, 详细请查看[react-native/share](https://github.com/facebook/react-native/blob/master/Libraries/Share/Share.js#L80) ） | (error):void |  无  |
+| successCallback       | 分享成功调用（`仅支持iOS`, 详细请查看[react-native/share](https://github.com/facebook/react-native/blob/master/Libraries/Share/Share.js#L80) ） | (completed:Boolean, activityType?:String):void |  无  |
 
-- options (array of strings) - 按钮标题列表 (required)
-- cancelButtonIndex (int) - 按钮列表中取消按钮的索引位置
-- destructiveButtonIndex (int) - 按钮列表中破坏性按钮（一般为删除）的索引位置
-- title (string) - 顶部标题
-- message (string/React.element) - 顶部标题下的简要消息
+显示分享动作面板，`options`对象必须包含以下的一个或者多个：
+属性 | 说明 | 类型 | 默认值
+----|-----|------|------
+| message       | 顶部标题下的简要消息 | String |  无  |
+| title       | 顶部标题  | String |  无  |
+| url       | 分享的 url `仅支持iOS`  | String |  无  |
+| excludedActivityTypes       | 指定在动作面板中不显示的活动`仅支持iOS`  | Array |  无  |
 
-#### static showShareActionSheetWithOptions(options: Object, failureCallback: Function, successCallback: Function)
-
-`React-Native only, react-native@version >= 0.39`
-
-显示分享 action sheet，`options`对象必须包含以下的一个或者多个：
-
-- **options:**
-  - message(`string`): 顶部标题下的简要消息
-  - title(`string`): 顶部标题
-  - url(`string`): 分享的 url `iOS only`
-  - excludedActivityTypes(`array`): 指定在actionsheet中不显示的活动 `iOS only`
-- **Callback**: (`iOS only`, see [react-native/share](https://github.com/facebook/react-native/blob/master/Libraries/Share/Share.js#L80))
-  - failureCallback(error): 分享失败调用；
-  - successCallback(completed, method)：分享成功调用;
-
-#### static close() - (android only) programmatically close.
+### ActionSheet.close()
+关闭动作面板`仅支持Android`

--- a/components/action-sheet/index.zh-CN.md
+++ b/components/action-sheet/index.zh-CN.md
@@ -21,6 +21,7 @@ subtitle: 动作面板
 | options       | 动作面板配置 | Object |  无  |
 | callback       | 操作成功后调用  | (index:number):void |  无  |
 显示动作面板，`options`对象必须包含以下的一个或者多个：
+
 属性 | 说明 | 类型 | 默认值
 ----|-----|------|------
 | options       | 按钮标题列表 (必须) | Array 或 String |  无  |
@@ -29,9 +30,9 @@ subtitle: 动作面板
 | title       | 顶部标题  | String |  无  |
 | message       | 顶部标题下的简要消息  | String 或 React.element |  无  |
 
-
 ### ActionSheet.showShareActionSheetWithOptions(options, failureCallback?, successCallback?)
 `仅支持React-Native,且react-native@version >= 0.39`
+
 属性 | 说明 | 类型 | 默认值
 ----|-----|------|------
 | options       | 动作面板配置 | Object |  无  |
@@ -39,6 +40,7 @@ subtitle: 动作面板
 | successCallback       | 分享成功调用（`仅支持iOS`, 详细请查看[react-native/share](https://github.com/facebook/react-native/blob/master/Libraries/Share/Share.js#L80) ） | (completed:Boolean, activityType?:String):void |  无  |
 
 显示分享动作面板，`options`对象必须包含以下的一个或者多个：
+
 属性 | 说明 | 类型 | 默认值
 ----|-----|------|------
 | message       | 顶部标题下的简要消息 | String |  无  |


### PR DESCRIPTION
现`动作面板`文档中`api描述`不太完善
<img width="1267" alt="ActionSheetDocs" src="https://user-images.githubusercontent.com/36829924/166472684-0c0f925c-a974-43f9-9fc8-28d95288f86c.png">
故按照其他组件的文档格式，完善了`动作面板`的`api描述`
<img width="1433" alt="ActionSheetDocsUpdate-1" src="https://user-images.githubusercontent.com/36829924/166473009-f84b7cdb-15af-4a85-bb57-3851357567bc.png">
<img width="1458" alt="ActionSheetDocsUpdate-2" src="https://user-images.githubusercontent.com/36829924/166473048-714cc238-d22d-46f5-8c07-9bc023edd82d.png">

