### PR TITLE
fix: disable modal button before press handler promise becomes to resolve state

### DIFF
--- a/components/modal/AlertContainer.tsx
+++ b/components/modal/AlertContainer.tsx
@@ -49,15 +49,15 @@ export default class AlertContainer extends React.Component<
     const footer = actions.map((button) => {
       // tslint:disable-next-line:only-arrow-functions
       const originPress = button.onPress || function () {}
-      button.onPress = () => {
-        const res = originPress()
-        if (res && res.then) {
-          res.then(() => {
-            this.onClose()
-          })
-        } else {
-          this.onClose()
+      const originStyle = button.style
+      button.onPress = async () => {
+        if (button.style === 'disabled') {
+          return
         }
+        button.style = 'disabled'
+        await originPress()
+        button.style = originStyle
+        this.onClose()
       }
       return button
     })

--- a/components/modal/AlertContainer.tsx
+++ b/components/modal/AlertContainer.tsx
@@ -48,7 +48,7 @@ export default class AlertContainer extends React.Component<
     const { title, actions, content, onAnimationEnd } = this.props
     const footer = actions.map((button) => {
       // tslint:disable-next-line:only-arrow-functions
-      const originPress = button.onPress || function () {}
+      const originPress = button.onPress ?? function () {}
       const originStyle = button.style
       button.onPress = async () => {
         if (button.style === 'disabled') {

--- a/components/modal/AlertContainer.tsx
+++ b/components/modal/AlertContainer.tsx
@@ -48,9 +48,9 @@ export default class AlertContainer extends React.Component<
     const { title, actions, content, onAnimationEnd } = this.props
     const footer = actions.map((button) => {
       // tslint:disable-next-line:only-arrow-functions
-      const orginPress = button.onPress || function () {}
+      const originPress = button.onPress || function () {}
       button.onPress = () => {
-        const res = orginPress()
+        const res = originPress()
         if (res && res.then) {
           res.then(() => {
             this.onClose()

--- a/components/modal/AlertContainer.tsx
+++ b/components/modal/AlertContainer.tsx
@@ -55,9 +55,14 @@ export default class AlertContainer extends React.Component<
           return
         }
         button.style = 'disabled'
-        await originPress()
-        button.style = originStyle
-        this.onClose()
+        // developer should handle the errors by themselves,
+        // so we don't need to do anything at here
+        try {
+          await originPress()
+        } finally {
+          button.style = originStyle
+          this.onClose()
+        }
       }
       return button
     })

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -105,6 +105,7 @@ class AntmModal extends React.Component<ModalProps, any> {
                     cancel: { color: '#000' },
                     default: {},
                     destructive: { color: 'red' },
+                    disabled: { color: 'lightgray' },
                   }
                   buttonStyle = styleMap[buttonStyle] || {}
                 }

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -98,7 +98,7 @@ class AntmModal extends React.Component<ModalProps, any> {
               }
               if (button.style) {
                 buttonStyle = button.style
-                if (typeof buttonStyle === 'string') {
+                if (typeof button.style === 'string') {
                   const styleMap: {
                     [key: string]: object
                   } = {
@@ -107,7 +107,7 @@ class AntmModal extends React.Component<ModalProps, any> {
                     destructive: { color: 'red' },
                     disabled: { color: 'lightgray' },
                   }
-                  buttonStyle = styleMap[buttonStyle] || {}
+                  buttonStyle = styleMap[button.style] || {}
                 }
               }
               const noneBorder =


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

主要修复：当Model.alert的OK按钮的onPress为一个async function时，点击按钮后需要暂时将该按钮禁用，直到onPress函数的Promise被resolve后才能将OK按钮恢复为启用状态。另外，buttonStyle的生成逻辑也有问题，在这个PR顺带做了修复。
最后，我本地执行test：all和lint都出错，请问你们之前有遇到类似情况吗？是如何处理的呢？
![image](https://user-images.githubusercontent.com/11588555/185699771-9eed07a4-fe6a-4e9b-acb8-db770ab31d64.png)
![image](https://user-images.githubusercontent.com/11588555/185699829-c6a407e2-45d5-4aaf-a7ab-fc47e8c3a71d.png)



Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
