### PR TITLE
fix(#1253): `Tabs.goToTab()` compiled incorrectly

### DIFF
--- a/components/tabs/Tabs.tsx
+++ b/components/tabs/Tabs.tsx
@@ -260,8 +260,12 @@ export class Tabs extends React.PureComponent<TabsProps, StateType> {
     if (this.carousel) {
       this.carousel.goTo(index)
     }
-    this.setState({ currentTab: index }, () => {
+    this.setState((prevState) => {
       this.state.scrollX.setValue(index * this.state.containerWidth)
+      return {
+        ...prevState,
+        currentTab: index,
+      }
     })
   }
 


### PR DESCRIPTION
Fixes issue https://github.com/ant-design/ant-design-mobile-rn/issues/1253