### PR TITLE
v5.0.2

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,12 @@ toc: false
 ---
 
 ### 5.0.01
+`2022-10-13`
+ - fix: type error on React 18 [#1257](https://github.com/ant-design/ant-design-mobile-rn/pull/1257) [@lhr000lhr](https://github.com/lhr000lhr)
+ - fix: `EventEmitter.removeListener` warning [#1200](https://github.com/ant-design/ant-design-mobile-rn/issues/1200)
+ - feat: children as react element in button [#1260](https://github.com/ant-design/ant-design-mobile-rn/pull/1260) [@lucas-it](https://github.com/lucas-it)
+
+### 5.0.01
 `2022-08-11`
  - fix: Tabs `onChange` no-call [#1241](https://github.com/ant-design/ant-design-mobile-rn/issues/1241)
  - fix: add libraries required for version 5.0.0 [#1228](https://github.com/ant-design/ant-design-mobile-rn/pull/1228)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,13 @@ toc: false
 ---
 
 ### 5.0.01
+`2022-10-13`
+ - fix: type error on React 18 [#1257](https://github.com/ant-design/ant-design-mobile-rn/pull/1257) [@lhr000lhr](https://github.com/lhr000lhr)
+ - fix: `EventEmitter.removeListener` warning [#1200](https://github.com/ant-design/ant-design-mobile-rn/issues/1200)
+ - feat: 组件Button `children` 支持ReactNode类型 [#1260](https://github.com/ant-design/ant-design-mobile-rn/pull/1260) [@lucas-it](https://github.com/lucas-it)
+
+
+### 5.0.01
 `2022-08-11`
  - fix: `Tabs`的`onChange`事件没有被调用 [#1241](https://github.com/ant-design/ant-design-mobile-rn/issues/1241)
  - fix: add libraries required for version 5.0.0 [#1228](https://github.com/ant-design/ant-design-mobile-rn/pull/1228)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/react-native",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "基于蚂蚁金服移动设计规范的 React Native 组件库",
   "keywords": [
     "ant",


### PR DESCRIPTION
CHANGELOG
 - fix: type error on React 18 (#1257)
 - fix: `EventEmitter.removeListener` warning (#1200)
 - feat: children as react element in button (#1260)