### PR TITLE
fix: children as react element in tabs

### DIFF
--- a/components/tabs/PropsType.tsx
+++ b/components/tabs/PropsType.tsx
@@ -100,4 +100,5 @@ export interface PropsType {
   useLeftInsteadTransform?: boolean
   style?: StyleProp<ViewStyle>
   keyboardShouldPersistTaps?: boolean
+  children?: React.ReactNode
 }


### PR DESCRIPTION
This PR adds the ability to pass a React element into the Tabs element. For example :

```tsx
<Tabs>
  <View>
    <Text>Content of Third Tab</Text>
  </View>
</Tabs>
```