### PR TITLE
fix: 修复传入right视图不渲染或同时传入left、right，right渲染成left内容的问题

### DIFF
--- a/components/swipe-action/index.tsx
+++ b/components/swipe-action/index.tsx
@@ -7,11 +7,11 @@ import {
   Text,
   TextStyle,
   View,
-  ViewStyle,
+  ViewStyle
 } from 'react-native'
 import {
   PanGestureHandlerProps,
-  RectButton,
+  RectButton
 } from 'react-native-gesture-handler'
 import Swipeable from 'react-native-gesture-handler/Swipeable'
 
@@ -97,7 +97,7 @@ class SwipeAction extends React.Component<SwipeActionProps> {
         leftThreshold={30}
         rightThreshold={40}
         renderLeftActions={(v, d) => this.renderActions(v, d, true)}
-        renderRightActions={this.renderActions}
+        renderRightActions={(v, d) => this.renderActions(v, d, false)}
         {...restProps}>
         {children}
       </Swipeable>

--- a/components/swipe-action/index.tsx
+++ b/components/swipe-action/index.tsx
@@ -7,11 +7,11 @@ import {
   Text,
   TextStyle,
   View,
-  ViewStyle
+  ViewStyle,
 } from 'react-native'
 import {
   PanGestureHandlerProps,
-  RectButton
+  RectButton,
 } from 'react-native-gesture-handler'
 import Swipeable from 'react-native-gesture-handler/Swipeable'
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22414351/204704744-c6523153-b9c2-4b8a-96e8-e7d0b606c54e.png)
![image](https://user-images.githubusercontent.com/22414351/204704743-92622ea4-a782-4e9f-8255-8d2ecbb86b88.png)
![image](https://user-images.githubusercontent.com/22414351/204704786-3b1bb470-a024-48a8-a344-f85f0708c114.png)
![image](https://user-images.githubusercontent.com/22414351/204704853-6251ed16-0fcf-4ccf-bf0b-b22716dcae79.png)
在 react-native-gesture-handler ^2.8.0 中
![image](https://user-images.githubusercontent.com/22414351/204704918-048b9c55-ebcd-4dd2-9d9d-816c358309b0.png)
