### PR TITLE
bump 5.0.5

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -14,6 +14,13 @@ toc: false
 
 ---
 
+### 5.0.5
+`2023-11-08`
+- fix: Picker support `numberOfLines` property [#1311](https://github.com/ant-design/ant-design-mobile-rn/issues/1311)
+  - fix: NativePicker.android.js support numberOfLines [~commit](https://github.com/ant-design/ant-design-mobile-rn/commit/f4505bbf291f12ec492489956ef34608e324af22)
+- fix: Tabs `swipeable` work [#1305](https://github.com/ant-design/ant-design-mobile-rn/issues/1305)
+- feat: gird replace Flex with View wrapper [~commit](https://github.com/ant-design/ant-design-mobile-rn/commit/a1dcf1c44ee505facdd6e7d8717710c61edc6f4f)
+
 ### 5.0.4
 `2023-02-20`
 - fix: children as react element in `@type/react@18`(last) [~commit](https://github.com/ant-design/ant-design-mobile-rn/commit/0d08b6bfe90f923f14155734979e551815ee9b0b)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -14,6 +14,13 @@ toc: false
 
 ---
 
+### 5.0.5
+`2023-11-08`
+- fix: Picker support `numberOfLines` property [#1311](https://github.com/ant-design/ant-design-mobile-rn/issues/1311)
+  - fix: NativePicker.android.js support numberOfLines [~commit](https://github.com/ant-design/ant-design-mobile-rn/commit/f4505bbf291f12ec492489956ef34608e324af22)
+- fix: Tabs `swipeable` work [#1305](https://github.com/ant-design/ant-design-mobile-rn/issues/1305)
+- feat: gird replace Flex with View wrapper [~commit](https://github.com/ant-design/ant-design-mobile-rn/commit/a1dcf1c44ee505facdd6e7d8717710c61edc6f4f)
+
 ### 5.0.4
 `2023-02-20`
 - fix: children as react element in `@type/react@18`(剩余所有) [~commit](https://github.com/ant-design/ant-design-mobile-rn/commit/0d08b6bfe90f923f14155734979e551815ee9b0b)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/react-native",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "基于蚂蚁金服移动设计规范的 React Native 组件库",
   "keywords": [
     "ant",


### PR DESCRIPTION
CHANGELOG
- fix: Picker support `numberOfLines` property [#1311](https://github.com/ant-design/ant-design-mobile-rn/issues/1311)
  - fix: NativePicker.android.js support numberOfLines [~commit](https://github.com/ant-design/ant-design-mobile-rn/commit/f4505bbf291f12ec492489956ef34608e324af22)
- fix: Tabs `swipeable` work [#1305](https://github.com/ant-design/ant-design-mobile-rn/issues/1305)
- feat: gird replace Flex with View wrapper [~commit](https://github.com/ant-design/ant-design-mobile-rn/commit/a1dcf1c44ee505facdd6e7d8717710c61edc6f4f)