### PR TITLE
v5.1.1

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -14,6 +14,12 @@ toc: false
 
 ---
 
+### 5.1.1
+`2024-03-15`
+- **PickerView** & **DatePickerView** & **Carousel** 
+  - fix: remove import `react-native-gesture-handler/ScrollView`
+  - Let the user decide whether to use by `_ScrollViewComponent` prop
+
 ### 5.1.0
 `2024-02-20`
 - Refactor **Picker** & **PickerView**

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -14,6 +14,12 @@ toc: false
 
 ---
 
+### 5.1.1
+`2024-03-15`
+- **PickerView** & **DatePickerView** & **Carousel** 
+  - fix: 移除 `react-native-gesture-handler/ScrollView` 引用
+  - 提供 `_ScrollViewComponent` 属性让用户决定是否使用
+
 ### 5.1.0
 `2024-02-23`
 - 重构 **Picker** & **PickerView**

--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ yarn add @ant-design/react-native
 ### Installing peer dependencies
 
 ```bash
-npm install @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler
+npm install @react-native-community/segmented-control @react-native-community/slider
 ```
 
 or
 
 ```bash
-yarn add @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler
+yarn add @react-native-community/segmented-control @react-native-community/slider
 ```
 
 > You need go to ios folder and run `pod install` (auto linking)，Android will handle it by itself.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,13 +99,13 @@ yarn add @ant-design/react-native
 ### 安装peer依赖
 
 ```bash
-npm install @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler
+npm install @react-native-community/segmented-control @react-native-community/slider
 ```
 
 or
 
 ```bash
-yarn add @react-native-community/segmented-control @react-native-community/slider react-native-gesture-handler
+yarn add @react-native-community/segmented-control @react-native-community/slider
 ```
 
 > 安装完依赖后需要到 iOS 目录 `pod install`(auto linking)，Android 不需要手动处理

--- a/components/carousel/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/carousel/__tests__/__snapshots__/demo.test.js.snap
@@ -27,7 +27,6 @@ exports[`renders ./components/carousel/demo/basic.tsx correctly 1`] = `
         automaticallyAdjustContentInsets={false}
         autoplay={true}
         autoplayInterval={3000}
-        collapsable={false}
         contentOffset={
           Object {
             "x": 0,
@@ -40,8 +39,6 @@ exports[`renders ./components/carousel/demo/basic.tsx correctly 1`] = `
         dots={true}
         horizontal={true}
         infinite={true}
-        onGestureHandlerEvent={[Function]}
-        onGestureHandlerStateChange={[Function]}
         onMomentumScrollEnd={[Function]}
         onScrollBeginDrag={[Function]}
         onScrollEndDrag={[Function]}
@@ -495,7 +492,6 @@ exports[`renders ./components/carousel/demo/basic.tsx correctly 1`] = `
         automaticallyAdjustContentInsets={false}
         autoplay={true}
         autoplayInterval={3000}
-        collapsable={false}
         contentOffset={
           Object {
             "x": 0,
@@ -508,8 +504,6 @@ exports[`renders ./components/carousel/demo/basic.tsx correctly 1`] = `
         dots={true}
         horizontal={false}
         infinite={true}
-        onGestureHandlerEvent={[Function]}
-        onGestureHandlerStateChange={[Function]}
         onMomentumScrollEnd={[Function]}
         onScrollBeginDrag={[Function]}
         onScrollEndDrag={[Function]}

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -4,12 +4,12 @@ import {
   NativeScrollEvent,
   NativeSyntheticEvent,
   Platform,
+  ScrollView,
   ScrollViewProps,
   StyleProp,
   View,
   ViewStyle,
 } from 'react-native'
-import { ScrollView } from 'react-native-gesture-handler'
 import devWarning from '../_util/devWarning'
 import { WithTheme, WithThemeStyles } from '../style'
 import CarouselStyles, { CarouselStyle } from './style/index'

--- a/components/carousel/index.tsx
+++ b/components/carousel/index.tsx
@@ -27,6 +27,10 @@ export interface CarouselPropsType
   autoplay?: boolean
   autoplayInterval?: number
   infinite?: boolean
+  /**
+   * @description To fix: Carousel not scrolling in Android ScrollView
+   */
+  _ScrollViewComponent?: any
 }
 
 export interface CarouselProps extends CarouselPropsType {
@@ -459,8 +463,9 @@ class Carousel extends React.PureComponent<CarouselProps, CarouselState> {
   }
 
   private renderScroll = (pages: React.ReactNode) => {
+    const ScrollViewComponent = this.props._ScrollViewComponent || ScrollView
     return (
-      <ScrollView
+      <ScrollViewComponent
         {...this.props}
         horizontal={!this.props.vertical}
         ref={this.scrollview as any}
@@ -483,7 +488,7 @@ class Carousel extends React.PureComponent<CarouselProps, CarouselState> {
             }
           : {})}>
         {pages}
-      </ScrollView>
+      </ScrollViewComponent>
     )
   }
 

--- a/components/date-picker-view/PropsType.tsx
+++ b/components/date-picker-view/PropsType.tsx
@@ -16,7 +16,7 @@ export interface DatePickerViewPropsType
     | 'numberOfLines'
     | 'renderMaskTop'
     | 'renderMaskBottom'
-    | 'withWrapper'
+    | '_ScrollViewComponent'
   > {
   value?: PickerDate
   defaultValue?: PickerDate

--- a/components/date-picker-view/PropsType.tsx
+++ b/components/date-picker-view/PropsType.tsx
@@ -16,6 +16,7 @@ export interface DatePickerViewPropsType
     | 'numberOfLines'
     | 'renderMaskTop'
     | 'renderMaskBottom'
+    | 'withWrapper'
   > {
   value?: PickerDate
   defaultValue?: PickerDate

--- a/components/date-picker-view/demo/basic.tsx
+++ b/components/date-picker-view/demo/basic.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { ScrollView, Text } from 'react-native'
-import { createNativeWrapper } from 'react-native-gesture-handler'
+import { ScrollView as GestureScrollView } from 'react-native-gesture-handler'
 import { DatePickerView } from '../../'
 import { DatePickerFilter } from '../../date-picker/date-picker-utils'
 
@@ -40,12 +40,7 @@ export default () => {
         precision="hour"
         renderLabel={labelRenderer}
         filter={dateFilter}
-        withWrapper={(Component) =>
-          createNativeWrapper(Component, {
-            disallowInterruption: true,
-            shouldCancelWhenOutside: false,
-          })
-        }
+        _ScrollViewComponent={GestureScrollView}
       />
     </ScrollView>
   )

--- a/components/date-picker-view/demo/basic.tsx
+++ b/components/date-picker-view/demo/basic.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { ScrollView, Text } from 'react-native'
+import { createNativeWrapper } from 'react-native-gesture-handler'
 import { DatePickerView } from '../../'
 import { DatePickerFilter } from '../../date-picker/date-picker-utils'
 
@@ -39,6 +40,12 @@ export default () => {
         precision="hour"
         renderLabel={labelRenderer}
         filter={dateFilter}
+        withWrapper={(Component) =>
+          createNativeWrapper(Component, {
+            disallowInterruption: true,
+            shouldCancelWhenOutside: false,
+          })
+        }
       />
     </ScrollView>
   )

--- a/components/date-picker/index.tsx
+++ b/components/date-picker/index.tsx
@@ -1,3 +1,4 @@
 import DatePicker from './date-picker'
+export type { DatePickerFilter, Precision } from './date-picker-utils'
 
 export default DatePicker

--- a/components/grid/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/grid/__tests__/__snapshots__/demo.test.js.snap
@@ -919,7 +919,6 @@ exports[`renders ./components/grid/demo/basic.tsx correctly 1`] = `
         automaticallyAdjustContentInsets={false}
         autoplay={false}
         autoplayInterval={3000}
-        collapsable={false}
         contentOffset={
           Object {
             "x": 0,
@@ -932,8 +931,6 @@ exports[`renders ./components/grid/demo/basic.tsx correctly 1`] = `
         dots={true}
         horizontal={true}
         infinite={false}
-        onGestureHandlerEvent={[Function]}
-        onGestureHandlerStateChange={[Function]}
         onMomentumScrollEnd={[Function]}
         onScrollBeginDrag={[Function]}
         onScrollEndDrag={[Function]}

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -8,6 +8,7 @@ export { default as Carousel } from './carousel/index'
 export { default as Checkbox } from './checkbox/index'
 export { default as DatePickerView } from './date-picker-view/index'
 export { default as DatePicker } from './date-picker/index'
+export type { DatePickerFilter, Precision } from './date-picker/index'
 export { default as Drawer } from './drawer/index'
 export { default as Flex } from './flex/index'
 export { default as Grid } from './grid/index'
@@ -20,6 +21,12 @@ export { default as NoticeBar } from './notice-bar/index'
 export { default as Pagination } from './pagination/index'
 export { default as PickerView } from './picker-view/index'
 export { default as Picker } from './picker/index'
+export type {
+  PickerColumn,
+  PickerColumnItem,
+  PickerValue,
+  PickerValueExtend,
+} from './picker/index'
 export { default as Popover } from './popover/index'
 export { default as Portal } from './portal/index'
 export { default as Progress } from './progress/index'
@@ -42,3 +49,7 @@ export { default as Toast } from './toast/index'
 export { default as View } from './view/index'
 export { default as WhiteSpace } from './white-space/index'
 export { default as WingBlank } from './wing-blank/index'
+/**
+ * @deprecated
+ */
+export class ImagePicker {}

--- a/components/picker-view/PropsType.tsx
+++ b/components/picker-view/PropsType.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react'
-import { ComponentType } from 'react'
 import { StyleProp, TextStyle, ViewStyle } from 'react-native'
 
 export type PickerValue = string | number
@@ -35,18 +34,5 @@ export interface PickerViewPropsType {
   renderLabel?: (item: PickerColumnItem, index: number) => ReactNode
   renderMaskTop?: () => ReactNode
   renderMaskBottom?: () => ReactNode
-  /**
-   * @description HOC for Wheel
-   * @example ```tsx
-   * import { createNativeWrapper } from 'react-native-gesture-handler'
-   *
-   * withWrapper={(Component) =>
-   *  createNativeWrapper(Component, {
-   *    disallowInterruption: true,
-   *    shouldCancelWhenOutside: false,
-   *  })
-   * }
-   * ```
-   */
-  withWrapper?: (Component: ComponentType<any>) => ComponentType<any>
+  _ScrollViewComponent?: any
 }

--- a/components/picker-view/PropsType.tsx
+++ b/components/picker-view/PropsType.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { ComponentType } from 'react'
 import { StyleProp, TextStyle, ViewStyle } from 'react-native'
 
 export type PickerValue = string | number
@@ -16,7 +17,6 @@ export type PickerColumnItem = {
 }
 
 export type PickerColumn = PickerColumnItem[]
-// type PickerColumn = (string | PickerColumnItem)[] // TODO: support string type
 
 export interface PickerViewPropsType {
   value?: PickerValue[]
@@ -35,4 +35,18 @@ export interface PickerViewPropsType {
   renderLabel?: (item: PickerColumnItem, index: number) => ReactNode
   renderMaskTop?: () => ReactNode
   renderMaskBottom?: () => ReactNode
+  /**
+   * @description HOC for Wheel
+   * @example ```tsx
+   * import { createNativeWrapper } from 'react-native-gesture-handler'
+   *
+   * withWrapper={(Component) =>
+   *  createNativeWrapper(Component, {
+   *    disallowInterruption: true,
+   *    shouldCancelWhenOutside: false,
+   *  })
+   * }
+   * ```
+   */
+  withWrapper?: (Component: ComponentType<any>) => ComponentType<any>
 }

--- a/components/picker-view/Wheel.tsx
+++ b/components/picker-view/Wheel.tsx
@@ -1,4 +1,3 @@
-// 需要重构成translate3d
 import type { ReactNode } from 'react'
 import React from 'react'
 import {

--- a/components/picker-view/Wheel.tsx
+++ b/components/picker-view/Wheel.tsx
@@ -22,6 +22,7 @@ type Props = {
   renderLabel: (item: ColumnItem, index: number) => ReactNode
   itemHeight: number
   wheelHeight: number
+  _ScrollViewComponent?: any
 }
 
 class Wheel extends React.Component<Props> {
@@ -167,11 +168,12 @@ class Wheel extends React.Component<Props> {
   }
 
   render() {
+    const ScrollViewComponent = this.props._ScrollViewComponent || ScrollView
     return (
-      <ScrollView
+      <ScrollViewComponent
         style={{ flex: 1 }}
         horizontal={false}
-        ref={(el) => (this.scrollerRef = el)}
+        ref={(el: any) => (this.scrollerRef = el)}
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
         pagingEnabled={false}
@@ -191,7 +193,7 @@ class Wheel extends React.Component<Props> {
               onMomentumScrollEnd: this.onMomentumScrollEnd,
             })}>
         {this.renderItems()}
-      </ScrollView>
+      </ScrollViewComponent>
     )
   }
 }

--- a/components/picker-view/Wheel.tsx
+++ b/components/picker-view/Wheel.tsx
@@ -5,9 +5,9 @@ import {
   NativeScrollEvent,
   NativeSyntheticEvent,
   Platform,
+  ScrollView,
   View,
 } from 'react-native'
-import { ScrollView } from 'react-native-gesture-handler'
 
 type ColumnItem = {
   label: string | ReactNode

--- a/components/picker-view/demo/basic.tsx
+++ b/components/picker-view/demo/basic.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { ScrollView, Text } from 'react-native'
-import { createNativeWrapper } from 'react-native-gesture-handler'
+import { ScrollView as GestureScrollView } from 'react-native-gesture-handler'
 import { PickerView } from '../../'
 
 const basicColumns = [
@@ -42,12 +42,7 @@ export default class PickerViewExample extends React.Component {
             padding: 0,
           }}
           // To fix: Wheel not scrolling in Android ScrollView
-          withWrapper={(Component) =>
-            createNativeWrapper(Component, {
-              disallowInterruption: true,
-              shouldCancelWhenOutside: false,
-            })
-          }
+          _ScrollViewComponent={GestureScrollView}
         />
 
         <Text style={{ margin: 16 }}>受控模式</Text>

--- a/components/picker-view/demo/basic.tsx
+++ b/components/picker-view/demo/basic.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { ScrollView, Text } from 'react-native'
+import { createNativeWrapper } from 'react-native-gesture-handler'
 import { PickerView } from '../../'
 
 const basicColumns = [
@@ -40,6 +41,13 @@ export default class PickerViewExample extends React.Component {
           itemStyle={{
             padding: 0,
           }}
+          // To fix: Wheel not scrolling in Android ScrollView
+          withWrapper={(Component) =>
+            createNativeWrapper(Component, {
+              disallowInterruption: true,
+              shouldCancelWhenOutside: false,
+            })
+          }
         />
 
         <Text style={{ margin: 16 }}>受控模式</Text>

--- a/components/picker-view/picker-view.tsx
+++ b/components/picker-view/picker-view.tsx
@@ -32,7 +32,6 @@ export default class RMCPickerView extends React.Component<
     renderMaskBottom: () => (
       <View style={{ flex: 1, backgroundColor: 'rgba(255,255,255,0.8)' }} />
     ),
-    withWrapper: (Component: any) => Component,
   }
 
   constructor(props: RMCPickerViewProps) {
@@ -111,10 +110,9 @@ export default class RMCPickerView extends React.Component<
       numberOfLines,
       handleSelect,
       loadingContent,
-      withWrapper,
+      _ScrollViewComponent,
     } = this.props
     const itemHeight = this.props.itemHeight || this.state.itemHeight
-    const WheelHOC = withWrapper?.(Wheel) || Wheel
     return (
       <WithTheme themeStyles={pickerViewStyles} styles={styles}>
         {(s) =>
@@ -146,7 +144,7 @@ export default class RMCPickerView extends React.Component<
                   : itemHeight > 0 &&
                     wheelHeight > 0 &&
                     columns.map((column, index) => (
-                      <WheelHOC
+                      <Wheel
                         key={index}
                         index={index}
                         column={column}
@@ -155,6 +153,7 @@ export default class RMCPickerView extends React.Component<
                         itemHeight={itemHeight}
                         wheelHeight={wheelHeight}
                         renderLabel={this.renderLabel}
+                        _ScrollViewComponent={_ScrollViewComponent}
                       />
                     ))}
               </View>

--- a/components/picker-view/picker-view.tsx
+++ b/components/picker-view/picker-view.tsx
@@ -32,6 +32,7 @@ export default class RMCPickerView extends React.Component<
     renderMaskBottom: () => (
       <View style={{ flex: 1, backgroundColor: 'rgba(255,255,255,0.8)' }} />
     ),
+    withWrapper: (Component: any) => Component,
   }
 
   constructor(props: RMCPickerViewProps) {
@@ -110,8 +111,10 @@ export default class RMCPickerView extends React.Component<
       numberOfLines,
       handleSelect,
       loadingContent,
+      withWrapper,
     } = this.props
     const itemHeight = this.props.itemHeight || this.state.itemHeight
+    const WheelHOC = withWrapper?.(Wheel) || Wheel
     return (
       <WithTheme themeStyles={pickerViewStyles} styles={styles}>
         {(s) =>
@@ -133,7 +136,6 @@ export default class RMCPickerView extends React.Component<
               <View style={[s.wheelWrapper, { height: wheelHeight }]}>
                 {(loading || columns?.length === 0) && loading !== false
                   ? loadingContent || (
-                      // TODO-luokun: loading样式优化
                       <View style={{ flex: 1, alignSelf: 'center' }}>
                         <ActivityIndicator
                           animating
@@ -144,7 +146,7 @@ export default class RMCPickerView extends React.Component<
                   : itemHeight > 0 &&
                     wheelHeight > 0 &&
                     columns.map((column, index) => (
-                      <Wheel
+                      <WheelHOC
                         key={index}
                         index={index}
                         column={column}

--- a/components/picker/Picker.tsx
+++ b/components/picker/Picker.tsx
@@ -7,7 +7,6 @@ import React, {
   useMemo,
   useState,
 } from 'react'
-import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { Omit } from 'utility-types'
 
 import { getComponentLocale } from '../_util/getLocale'
@@ -156,14 +155,12 @@ const RMCPicker = forwardRef<PickerRef, RMCPickerProps>((props, ref) => {
         {/* TODO: 组件卸载是在visible更新fasle之后,需要前置 */}
         {/* 否则会无效执行onPickerChange */}
         {innerVisible && (
-          <GestureHandlerRootView>
-            <RMCPickerView
-              {...restProps}
-              value={value}
-              columns={columns}
-              handleSelect={handleSelect}
-            />
-          </GestureHandlerRootView>
+          <RMCPickerView
+            {...restProps}
+            value={value}
+            columns={columns}
+            handleSelect={handleSelect}
+          />
         )}
       </PopupPicker>
       {renderChildren()}

--- a/components/picker/__tests__/__snapshots__/index.test.js.snap
+++ b/components/picker/__tests__/__snapshots__/index.test.js.snap
@@ -201,43 +201,41 @@ Array [
             </Text>
           </View>
         </View>
-        <View>
+        <View
+          onLayout={[Function]}
+        >
           <View
-            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "height": "auto",
+                  "justifyContent": "center",
+                  "overflow": "hidden",
+                },
+              ]
+            }
           >
-            <View
+            <Text
+              numberOfLines={1}
               style={
                 Array [
                   Object {
+                    "color": "#333",
+                    "fontSize": 16,
+                    "includeFontPadding": false,
+                    "padding": 8,
+                    "textAlign": "center",
+                  },
+                  undefined,
+                  Object {
                     "height": "auto",
-                    "justifyContent": "center",
-                    "overflow": "hidden",
                   },
                 ]
               }
             >
-              <Text
-                numberOfLines={1}
-                style={
-                  Array [
-                    Object {
-                      "color": "#333",
-                      "fontSize": 16,
-                      "includeFontPadding": false,
-                      "padding": 8,
-                      "textAlign": "center",
-                    },
-                    undefined,
-                    Object {
-                      "height": "auto",
-                    },
-                  ]
-                }
-              >
-                
-                　
-              </Text>
-            </View>
+              
+              　
+            </Text>
           </View>
         </View>
       </View>

--- a/components/picker/index.tsx
+++ b/components/picker/index.tsx
@@ -8,12 +8,18 @@ import React, {
   useState,
 } from 'react'
 import { mergeProps } from '../_util/with-default-props'
-import { PickerValue } from '../picker-view/PropsType'
+import {
+  PickerColumn,
+  PickerColumnItem,
+  PickerValue,
+  PickerValueExtend,
+} from '../picker-view/PropsType'
 import { getColumns, getValueExtend } from '../picker-view/columns-extend'
 import RMCPicker, { PickerRef } from './Picker'
 import { PickerPropsType } from './PropsType'
 
 export interface PickerProps extends PickerPropsType {}
+export { PickerColumn, PickerColumnItem, PickerValue, PickerValueExtend }
 
 const defaultProps = {
   defaultValue: [],

--- a/example/App.js
+++ b/example/App.js
@@ -1,8 +1,7 @@
 import { useFonts } from 'expo-font'
 import * as SplashScreen from 'expo-splash-screen'
 import React, { useCallback } from 'react'
-import { View } from 'react-native'
-import 'react-native-gesture-handler'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import 'react-native-reanimated'
 import App from '../rn-kitchen-sink/App'
 
@@ -25,8 +24,8 @@ export default function () {
   }
 
   return (
-    <View onLayout={onLayoutRootView} style={{ flex: 1 }}>
+    <GestureHandlerRootView onLayout={onLayoutRootView} style={{ flex: 1 }}>
       <App />
-    </View>
+    </GestureHandlerRootView>
   )
 }

--- a/example/app.json
+++ b/example/app.json
@@ -22,7 +22,8 @@
     },
     "ios": {
       "bundler": "metro",
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.1uokun.antdesignmobilern"
     },
     "android": {
       "adaptiveIcon": {

--- a/example/eas.json
+++ b/example/eas.json
@@ -1,0 +1,11 @@
+{
+    "build": {
+      "preview": {
+        "ios": {
+          "simulator": true
+        }
+      },
+      "production": {}
+    }
+  }
+  

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+    <!-- 
+      This viewport works for phones with notches.
+      It's optimized for gestures by disabling global zoom.
+     -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover"
+    />
+    <title>@ant-design/react-native</title>
+    <style>
+      /**
+       * Extend the react-native-web reset:
+       * https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/StyleSheet/initialRules.js
+       */
+      html,
+      body,
+      #root {
+        width: 100%;
+        /* To smooth any scrolling behavior */
+        -webkit-overflow-scrolling: touch;
+        margin: 0px;
+        padding: 0px;
+        /* Allows content to fill the viewport and go beyond the bottom */
+        min-height: 100%;
+      }
+      #root {
+        flex-shrink: 0;
+        flex-basis: auto;
+        flex-grow: 1;
+        display: flex;
+        flex: 1;
+      }
+
+      html {
+        scroll-behavior: smooth;
+        /* Prevent text size change on orientation change https://gist.github.com/tfausak/2222823#file-ios-8-web-app-html-L138 */
+        -webkit-text-size-adjust: 100%;
+        height: calc(100% + env(safe-area-inset-top));
+      }
+
+      body {
+        display: flex;
+        /* Allows you to scroll below the viewport; default value is visible */
+        overflow-y: auto;
+        overscroll-behavior-y: none;
+        text-rendering: optimizeLegibility;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        -ms-overflow-style: scrollbar;
+      }
+      /* Enable for apps that support dark-theme */
+      /*@media (prefers-color-scheme: dark) {
+        body {
+          background-color: black;
+        }
+      }*/
+    </style>
+  </head>
+
+  <body>
+    <!-- 
+      A generic no script element with a reload button and a message.
+      Feel free to customize this however you'd like.
+    -->
+    <noscript>
+      <form
+        action=""
+        style="
+          background-color: #fff;
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          z-index: 9999;
+        "
+      >
+        <div
+          style="
+            font-size: 18px;
+            font-family: Helvetica, sans-serif;
+            line-height: 24px;
+            margin: 10%;
+            width: 80%;
+          "
+        >
+          <p>Oh no! It looks like JavaScript is not enabled in your browser.</p>
+          <p style="margin: 20px 0;">
+            <button
+              type="submit"
+              style="
+                background-color: #4630eb;
+                border-radius: 100px;
+                border: none;
+                box-shadow: none;
+                color: #fff;
+                cursor: pointer;
+                font-weight: bold;
+                line-height: 20px;
+                padding: 6px 16px;
+              "
+            >
+              Reload
+            </button>
+          </p>
+        </div>
+      </form>
+    </noscript>
+    <!-- The root element for your Expo app. -->
+    <div id="root"></div>
+  </body>
+</html>

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "extends": "expo/tsconfig.base"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/react-native",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "基于蚂蚁金服移动设计规范的 React Native 组件库",
   "keywords": [
     "ant",

--- a/package.json
+++ b/package.json
@@ -102,8 +102,7 @@
     "@react-native-community/segmented-control": ">= 1.4.0",
     "@react-native-community/slider": ">= 2.0.0",
     "react": ">=17.0.1",
-    "react-native": ">=0.64.1",
-    "react-native-gesture-handler": ">=2.2.1"
+    "react-native": ">=0.64.1"
   },
   "scripts": {
     "lint": "npm run tslint && npm run srclint && npm run applint",

--- a/rn-kitchen-sink/components/index.js
+++ b/rn-kitchen-sink/components/index.js
@@ -1,12 +1,12 @@
 /* eslint no-console:0 */
 import React from 'react'
-import { Dimensions, ScrollView, StyleSheet, View } from 'react-native'
+import { ScrollView, StyleSheet, View } from 'react-native'
 import { List, SearchBar } from '../../components'
 import { OTHERS, UIBARS, UICONTROLS, UIVIEWS } from '../demoList'
 
 const styles = StyleSheet.create({
   container: {
-    height: Dimensions.get('window').height,
+    flex: 1,
   },
 })
 

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -46,5 +46,6 @@ Array [
   "View",
   "WhiteSpace",
   "WingBlank",
+  "ImagePicker",
 ]
 `;


### PR DESCRIPTION
# fix: java.lang.Boolean cannot be cast to java.lang.Double Bug
 - https://github.com/ant-design/ant-design-mobile-rn/issues/1329
 - https://github.com/ant-design/ant-design-mobile-rn/issues/1328
 - https://github.com/ant-design/ant-design-mobile-rn/issues/1327

## TODO
- [x] **PickerView** & **DatePickerView** & **Carousel** 
   - fix: remove import `react-native-gesture-handler/ScrollView`
   - Let the user decide whether to use by `_ScrollViewComponent` prop

## Q&A

- Q: Why import `react-native-gesture-handler/ScrollView` in 5.1.0
- A: to fix: Picker Wheel not scrolling in Android ScrollView

```jsx
import { ScrollView } from 'react-native'
import { ScrollView as GestureScrollView } from 'react-native-gesture-handler'

<ScrollView>

  <ScrollView>
   // ScrollView doesn't work with multiple scroll views in Android
  <SCrollVIew>

  <GestureScrollView>
  // it works
  </GestureScrollView>

<ScrollView>
```