### PR TITLE
fix: DataPicker black underlayColor

### DIFF
--- a/components/picker/Popup.tsx
+++ b/components/picker/Popup.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react'
-import { Text, TouchableHighlight, View } from 'react-native'
+import { Text, TouchableOpacity, View } from 'react-native'
 import Modal from '../modal/ModalView'
 import { PopupPickerProps } from './PopupPickerTypes'
 
@@ -43,21 +43,13 @@ const PopupPicker = memo((props: PopupPickerProps) => {
       visible={visible}
       onClose={onClose}>
       <View style={[styles.header]}>
-        <TouchableHighlight
-          onPress={onDismiss}
-          style={[styles.headerItem]}
-          activeOpacity={props.actionTextActiveOpacity}
-          underlayColor={props.actionTextUnderlayColor}>
+        <TouchableOpacity onPress={onDismiss} style={[styles.headerItem]}>
           {dismissEl}
-        </TouchableHighlight>
+        </TouchableOpacity>
         <View style={[styles.headerItem]}>{titleEl}</View>
-        <TouchableHighlight
-          onPress={onOk}
-          style={[styles.headerItem]}
-          activeOpacity={props.actionTextActiveOpacity}
-          underlayColor={props.actionTextUnderlayColor}>
+        <TouchableOpacity onPress={onOk} style={[styles.headerItem]}>
           {okEl}
-        </TouchableHighlight>
+        </TouchableOpacity>
       </View>
       {children}
     </Modal>

--- a/components/picker/PopupPickerTypes.tsx
+++ b/components/picker/PopupPickerTypes.tsx
@@ -10,6 +10,4 @@ export type PopupPickerProps = {
   dismissText?: ReactNode
   children?: ReactNode
   styles: any
-  actionTextUnderlayColor?: string
-  actionTextActiveOpacity?: number
 }


### PR DESCRIPTION
<img width="1310" alt="image" src="https://github.com/ant-design/ant-design-mobile-rn/assets/24217195/32c13d28-0e73-4e03-b053-53174917e308">
点击的时候，会出现黑色的底色