### PR TITLE
fix: navigation list safe area problem

### DIFF
--- a/rn-kitchen-sink/components/index.js
+++ b/rn-kitchen-sink/components/index.js
@@ -1,6 +1,6 @@
 /* eslint no-console:0 */
 import React from 'react'
-import { ScrollView, StyleSheet, View } from 'react-native'
+import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native'
 import { List, SearchBar } from '../../components'
 import { OTHERS, UIBARS, UICONTROLS, UIVIEWS } from '../demoList'
 
@@ -89,6 +89,7 @@ export default class RnIndex extends React.Component {
             </List>
           ))}
         </ScrollView>
+        <SafeAreaView />
       </View>
     )
   }


### PR DESCRIPTION
I had a problem that I couldn't select the navigation list on my iPhone X ~ iPhone 15.

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [ ] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.
