### PR TITLE
Fix forwardRef warning on InnerNoticeBar component

### DIFF
--- a/components/notice-bar/notice-bar.tsx
+++ b/components/notice-bar/notice-bar.tsx
@@ -6,7 +6,7 @@ import { Marquee } from './Marquee'
 import { NoticeBarProps } from './PropsType'
 import NoticeBarStyle from './style'
 
-export function InnerNoticeBar(props: NoticeBarProps) {
+export function InnerNoticeBar(props: NoticeBarProps, ref) {
   const ss = useTheme({
     styles: props.styles,
     themeStyles: NoticeBarStyle,

--- a/components/notice-bar/notice-bar.tsx
+++ b/components/notice-bar/notice-bar.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo, useState } from 'react'
+import React, { memo, useMemo, useState } from 'react'
 import { Text, TouchableWithoutFeedback, View } from 'react-native'
 import Icon from '../icon'
 import { useTheme } from '../style'
@@ -6,7 +6,7 @@ import { Marquee } from './Marquee'
 import { NoticeBarProps } from './PropsType'
 import NoticeBarStyle from './style'
 
-export function InnerNoticeBar(props: NoticeBarProps, ref) {
+export function InnerNoticeBar(props: NoticeBarProps) {
   const ss = useTheme({
     styles: props.styles,
     themeStyles: NoticeBarStyle,
@@ -75,4 +75,4 @@ export function InnerNoticeBar(props: NoticeBarProps, ref) {
   )
 }
 
-export const NoticeBar = forwardRef(InnerNoticeBar)
+export const NoticeBar = memo(InnerNoticeBar)


### PR DESCRIPTION
First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
  * [ ] Add unit tests for the feature.

`ref` should be added to `InnerNoticeBar` component even though it's not used. Otherwise, a warning will be thrown:

```
 ERROR  Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?
    in App
    in RCTView (created by View)
    in View (created by AppContainer)
    in RCTView (created by View)
    in View (created by AppContainer)
    in AppContainer
```

[issue link: https://github.com/ant-design/ant-design-mobile-rn/issues/1362](https://github.com/ant-design/ant-design-mobile-rn/issues/1362)
