### PR TITLE
fix: new Date not adhering to ISO 8601

### DIFF
--- a/components/date-picker-view/date-picker-view.tsx
+++ b/components/date-picker-view/date-picker-view.tsx
@@ -17,14 +17,15 @@ import { PickerViewStyle } from '../picker-view/style'
 import { WithThemeStyles } from '../style'
 import { DatePickerViewPropsType } from './PropsType'
 import useRenderLabel from './useRenderLabel'
+import dayjs from 'dayjs'
 
 export interface DatePickerViewProps
   extends DatePickerViewPropsType,
     WithThemeStyles<PickerViewStyle> {}
 
 const defaultProps = {
-  minDate: new Date('2000-1-1'),
-  maxDate: new Date('2030-1-1'),
+  minDate: dayjs('2000-1-1').toDate(),
+  maxDate: dayjs('2030-1-1').toDate(),
   mode: 'date',
 }
 

--- a/components/date-picker/date-picker.tsx
+++ b/components/date-picker/date-picker.tsx
@@ -26,8 +26,8 @@ export type DatePickerRef = any
 export interface DatePickerProps extends DatePickerPropsType {}
 
 const defaultProps = {
-  minDate: new Date('2000-1-1'),
-  maxDate: new Date('2030-1-1'),
+  minDate: dayjs('2000-1-1').toDate(),
+  maxDate: dayjs('2030-1-1').toDate(),
   precision: 'day',
 }
 


### PR DESCRIPTION

new Date() 解析如 2000-1-1时，不符合 ISO 8601 标准，react native会解析为NaN，修复后使用dayjs规范为ISO 8601 标准