### PR TITLE
fix: Tooltip arrow styling precedence issue

### DIFF
--- a/components/tooltip/Tooltip.tsx
+++ b/components/tooltip/Tooltip.tsx
@@ -186,7 +186,7 @@ const InternalTooltip: React.ForwardRefRenderFunction<
               collapsable={false}
               style={[ss.tooltip, safeFloatingStyles, style]}>
               <View
-                style={[ss.arrow, arrowPosition]}
+                style={[arrowPosition, ss.arrow]}
                 ref={arrowRef}
                 collapsable={false}
               />

--- a/components/tooltip/Tooltip.tsx
+++ b/components/tooltip/Tooltip.tsx
@@ -186,6 +186,7 @@ const InternalTooltip: React.ForwardRefRenderFunction<
               collapsable={false}
               style={[ss.tooltip, safeFloatingStyles, style]}>
               <View
+                testID="tooltip-arrow"
                 style={[arrowPosition, ss.arrow]}
                 ref={arrowRef}
                 collapsable={false}

--- a/components/tooltip/__tests__/index.test.js
+++ b/components/tooltip/__tests__/index.test.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { Text } from 'react-native'
+import renderer from 'react-test-renderer'
+import Provider from '../../provider'
+import Tooltip from '../index'
+
+describe('Tooltip', () => {
+  it('applies custom arrow styles correctly', () => {
+    const inst = renderer.create(
+      <Provider>
+        <Tooltip
+          content="Tooltip content"
+          placement="bottom"
+          visible={true}
+          styles={{
+            arrow: {
+              borderBottomColor: 'red',
+            },
+          }}>
+          <Text>Tooltip</Text>
+        </Tooltip>
+      </Provider>,
+    )
+    const arrow = inst.root.findByProps({ testID: 'tooltip-arrow' })
+
+    const extractBorderBottomColors = (styles) => {
+      const colors = []
+      const traverseStyles = (style) => {
+        if (Array.isArray(style)) {
+          style.forEach(traverseStyles)
+        } else if (
+          style &&
+          typeof style === 'object' &&
+          style.borderBottomColor
+        ) {
+          colors.push(style.borderBottomColor)
+        }
+      }
+      traverseStyles(styles)
+      return colors
+    }
+    const borderBottomColors = extractBorderBottomColors(arrow.props.style)
+    const lastBorderColor = borderBottomColors[borderBottomColors.length - 1]
+    expect(lastBorderColor).toEqual('red')
+  })
+})


### PR DESCRIPTION
# Fix Tooltip arrow styling precedence issue

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isBugFix* **:**

  * [x] Make sure that you add at least one unit test for the bug which you had fixed.

## Problem

In the `Tooltip` component, there's a styling precedence issue that prevents custom arrow colors from being applied correctly based on the tooltip's placement. Currently, the arrow's style is defined as:

```tsx
<View
  style={[ss.arrow, arrowPosition]}
  ref={arrowRef}
  collapsable={false}
/>
```

With this order, if `ss.arrow` comes before `arrowPosition`, it's not possible to override the `borderColor` property based on the current placement. This prevents proper styling customization of the tooltip arrow.

The issue is directly related to how `arrowPosition` is defined in the component:

```tsx
const arrowPosition = useMemo(() => {
  const side = realPlacement.split('-')[0] as string
  const arrowBorder = {
    top: 'borderTopColor',
    right: 'borderRightColor',
    bottom: 'borderBottomColor',
    left: 'borderLeftColor',
  }[side] as string
  const arrowSide = {
    top: 'bottom',
    right: 'left',
    bottom: 'top',
    left: 'right',
  }[side] as string
  return {
    left: arrowX || undefined,
    top: arrowY || undefined,
    [arrowSide]: -theme.tooltip_arrow_size * 2,
    [arrowBorder]: mode === 'dark' ? theme.tooltip_dark : theme.fill_base,
  }
}, [/* dependencies */])
```

Here, `arrowPosition` dynamically calculates which border color to apply (`borderTopColor`, `borderRightColor`, etc.) based on the tooltip's placement. Quando `ss.arrow` vem primeiro na matriz de estilos, suas propriedades de cor de borda sempre são substituidas pelos valores dinâmicos de `arrowPosition`.

## Solution

Swap the style order in the array so that `ss.arrow` has higher precedence:

```tsx
<View
  style={[arrowPosition, ss.arrow]}
  ref={arrowRef}
  collapsable={false}
/>
```

This change ensures that `ss.arrow` properties will have higher priority and can properly override the dynamic `borderColor` properties in `arrowPosition`, regardless of the tooltip's placement. By putting `arrowPosition` first and `ss.arrow` last, we allow the theme customization to take precedence, as styles later in the array have higher priority in React Native.

## Changes

- Reversed the order of style array elements for the tooltip arrow to ensure proper styling precedence
- No behavioral changes, only styling fixes

## Screenshot
 - Before (defaut color white)
![image](https://github.com/user-attachments/assets/05b6f5cd-4285-4c82-8201-a27c5c032243)

 - After
![image](https://github.com/user-attachments/assets/2f748877-a184-4370-848d-48e8e59e2cf8)



## Testing

- Verified that arrow colors are correctly applied for all placement options
- Tested with both light and dark mode
- Ensured no regression in arrow positioning or appearance

## Additional Notes

This is a minor but important fix that ensures theme customization works properly for tooltip arrows regardless of their placement. The issue was subtle because it only affected specific customization scenarios where custom arrow border colors needed to be applied depending on placement.