### PR TITLE
Fix Checkbox Indeterminate State Error

### DIFF
--- a/components/_util/hooks/useAnimations.tsx
+++ b/components/_util/hooks/useAnimations.tsx
@@ -17,7 +17,10 @@ type animateType = (_TimingAnimationConfig: {
 
 interface ConfigureInterface {
   initialValue: number
-  animate: animateType
+}
+
+interface AnimatedFuncParams extends Animated.TimingAnimationConfig {
+  callback?: Animated.EndCallback
 }
 
 // Animated.Value hook
@@ -36,6 +39,10 @@ export function useAnimate(configure: ConfigureInterface) {
 export function useAnimatedTiming(): [Animated.Value, animateType] {
   const animatedRef = React.useRef<Animated.CompositeAnimation | void>()
 
+  var [animatedValue] = useAnimate({
+    initialValue: 0,
+  })
+
   const animatedFunc = React.useCallback(
     ({
       toValue = 1,
@@ -44,7 +51,7 @@ export function useAnimatedTiming(): [Animated.Value, animateType] {
       delay,
       useNativeDriver = false,
       callback,
-    }) => {
+    }: AnimatedFuncParams) => {
       animatedRef.current?.stop()
       animatedRef.current = Animated.timing(animatedValue, {
         toValue,
@@ -54,13 +61,8 @@ export function useAnimatedTiming(): [Animated.Value, animateType] {
         useNativeDriver,
       }).start(callback)
     },
-    // @ts-ignore
     [animatedValue],
   )
-  var [animatedValue] = useAnimate({
-    initialValue: 0,
-    animate: animatedFunc,
-  })
 
   return [animatedValue, animatedFunc]
 }

--- a/components/accordion/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/accordion/__tests__/__snapshots__/demo.test.js.snap
@@ -107,7 +107,12 @@ exports[`renders ./components/accordion/demo/basic.tsx correctly 1`] = `
         <View
           collapsable={false}
           pointerEvents="auto"
-          style={Object {}}
+          style={
+            Object {
+              "height": 0,
+              "overflow": "hidden",
+            }
+          }
         >
           <View
             collapsable={false}
@@ -552,7 +557,12 @@ exports[`renders ./components/accordion/demo/basic.tsx correctly 1`] = `
         <View
           collapsable={false}
           pointerEvents="auto"
-          style={Object {}}
+          style={
+            Object {
+              "height": 0,
+              "overflow": "hidden",
+            }
+          }
         >
           <View
             collapsable={false}

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -152,7 +152,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<
                   style={[antd_checkbox_inner, transitionOpacity]}
                 />
                 <Animated.View
-                  style={[transitionTransform, antd_checkbox_inner_after]}
+                  style={[antd_checkbox_inner_after, transitionTransform]}
                 />
               </View>
             </View>

--- a/components/checkbox/Checkbox.tsx
+++ b/components/checkbox/Checkbox.tsx
@@ -54,18 +54,24 @@ const InternalCheckbox: React.ForwardRefRenderFunction<
       outputRange: [0, 1],
     }),
   }
-  const transitionTransform = {
-    transform: [
-      // hack: rotate & radius bug in android
-      ...(restProps.accessibilityRole === 'radio' ? [] : [{ rotate: '45deg' }]),
-      {
-        scale: animatedValue.interpolate({
-          inputRange: [0, 1],
-          outputRange: [0, 1],
-        }),
-      },
-    ],
-  }
+  const transitionTransform = useMemo(() => {
+    return {
+      transform: [
+        {
+          rotate: animatedValue.interpolate({
+            inputRange: [0, 1],
+            outputRange: ['0deg', '45deg'],
+          }),
+        },
+        {
+          scale: animatedValue.interpolate({
+            inputRange: [0, 1],
+            outputRange: indeterminate ? [1, 0] : [0, 1],
+          }),
+        },
+      ],
+    }
+  }, [animatedValue, indeterminate])
 
   //initial animate or receive props
   useEffect(() => {
@@ -121,10 +127,10 @@ const InternalCheckbox: React.ForwardRefRenderFunction<
           .split(' ')
           .map((a) => _styles[a])
 
-        const antd_checkbox_inner_after = classNames(undefined, {
-          [`${prefixCls}_inner_after`]: !indeterminate,
-          [`${prefixCls}_inner_after_indeterminate`]: indeterminate,
-          [`${prefixCls}_inner_after_disabled`]: disabled,
+        const antd_checkbox_inner_before = classNames(undefined, {
+          [`${prefixCls}_inner_before`]: !indeterminate,
+          [`${prefixCls}_inner_before_indeterminate`]: indeterminate,
+          [`${prefixCls}_inner_before_disabled`]: disabled,
         })
           .split(' ')
           .map((a) => _styles[a])
@@ -152,7 +158,7 @@ const InternalCheckbox: React.ForwardRefRenderFunction<
                   style={[antd_checkbox_inner, transitionOpacity]}
                 />
                 <Animated.View
-                  style={[antd_checkbox_inner_after, transitionTransform]}
+                  style={[antd_checkbox_inner_before, transitionTransform]}
                 />
               </View>
             </View>

--- a/components/checkbox/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.js.snap
@@ -151,7 +151,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                         "position": "absolute",
                         "transform": Array [
                           Object {
-                            "rotate": "45deg",
+                            "rotate": "0deg",
                           },
                           Object {
                             "scale": 0,
@@ -375,7 +375,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                         "position": "absolute",
                         "transform": Array [
                           Object {
-                            "rotate": "45deg",
+                            "rotate": "0deg",
                           },
                           Object {
                             "scale": 0,
@@ -557,7 +557,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                         "position": "absolute",
                         "transform": Array [
                           Object {
-                            "rotate": "45deg",
+                            "rotate": "0deg",
                           },
                           Object {
                             "scale": 0,
@@ -782,7 +782,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                         "position": "absolute",
                         "transform": Array [
                           Object {
-                            "rotate": "45deg",
+                            "rotate": "0deg",
                           },
                           Object {
                             "scale": 0,
@@ -1178,7 +1178,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                     "position": "absolute",
                     "transform": Array [
                       Object {
-                        "rotate": "45deg",
+                        "rotate": "0deg",
                       },
                       Object {
                         "scale": 0,
@@ -1373,7 +1373,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                         "position": "absolute",
                         "transform": Array [
                           Object {
-                            "rotate": "45deg",
+                            "rotate": "0deg",
                           },
                           Object {
                             "scale": 0,
@@ -1565,7 +1565,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                         "position": "absolute",
                         "transform": Array [
                           Object {
-                            "rotate": "45deg",
+                            "rotate": "0deg",
                           },
                           Object {
                             "scale": 0,
@@ -1757,7 +1757,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                         "position": "absolute",
                         "transform": Array [
                           Object {
-                            "rotate": "45deg",
+                            "rotate": "0deg",
                           },
                           Object {
                             "scale": 0,
@@ -2022,7 +2022,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                             "position": "absolute",
                             "transform": Array [
                               Object {
-                                "rotate": "45deg",
+                                "rotate": "0deg",
                               },
                               Object {
                                 "scale": 0,
@@ -2213,10 +2213,10 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                         "position": "absolute",
                         "transform": Array [
                           Object {
-                            "rotate": "45deg",
+                            "rotate": "0deg",
                           },
                           Object {
-                            "scale": 0,
+                            "scale": 1,
                           },
                         ],
                         "width": 8,
@@ -2420,7 +2420,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                           "position": "absolute",
                           "transform": Array [
                             Object {
-                              "rotate": "45deg",
+                              "rotate": "0deg",
                             },
                             Object {
                               "scale": 0,
@@ -2613,7 +2613,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                           "position": "absolute",
                           "transform": Array [
                             Object {
-                              "rotate": "45deg",
+                              "rotate": "0deg",
                             },
                             Object {
                               "scale": 0,
@@ -2809,7 +2809,7 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                           "position": "absolute",
                           "transform": Array [
                             Object {
-                              "rotate": "45deg",
+                              "rotate": "0deg",
                             },
                             Object {
                               "scale": 0,

--- a/components/checkbox/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/checkbox/__tests__/__snapshots__/demo.test.js.snap
@@ -2213,7 +2213,10 @@ exports[`renders ./components/checkbox/demo/basic.tsx correctly 1`] = `
                         "position": "absolute",
                         "transform": Array [
                           Object {
-                            "rotate": "0deg",
+                            "rotate": "45deg",
+                          },
+                          Object {
+                            "scale": 0,
                           },
                         ],
                         "width": 8,

--- a/components/checkbox/style/index.tsx
+++ b/components/checkbox/style/index.tsx
@@ -9,12 +9,12 @@ export interface CheckboxStyle {
   checkbox_disabled: ViewStyle
   checkbox_inner: ViewStyle
   checkbox_inner_disabled: ViewStyle
-  checkbox_inner_after: ViewStyle
-  checkbox_inner_after_disabled: ViewStyle
+  checkbox_inner_before: ViewStyle
+  checkbox_inner_before_disabled: ViewStyle
   checkbox_label: ViewStyle
   checkbox_label_disabled: ViewStyle
   checkbox_inner_indeterminate: ViewStyle
-  checkbox_inner_after_indeterminate: ViewStyle
+  checkbox_inner_before_indeterminate: ViewStyle
 }
 
 export default (theme: Theme) =>
@@ -68,8 +68,8 @@ export default (theme: Theme) =>
     },
 
     // ==========inner::after============
-    checkbox_inner_after: {
-      // transform: [{ rotate: '45deg' }],
+    checkbox_inner_before: {
+      transform: [{ rotate: '45deg' }],
       position: 'absolute',
       width: 6,
       height: 9,
@@ -80,14 +80,13 @@ export default (theme: Theme) =>
       borderLeftWidth: 0,
     },
     // 半选状态样式
-    checkbox_inner_after_indeterminate: {
-      transform: [{ rotate: '0deg' }],
+    checkbox_inner_before_indeterminate: {
       position: 'absolute',
       width: 8,
       height: 8,
       backgroundColor: theme.brand_primary,
     },
-    checkbox_inner_after_disabled: {
+    checkbox_inner_before_disabled: {
       borderColor: theme.checkbox_border_disabled,
     },
 

--- a/components/radio/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/radio/__tests__/__snapshots__/demo.test.js.snap
@@ -163,6 +163,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                         "position": "absolute",
                         "transform": Array [
                           Object {
+                            "rotate": "0deg",
+                          },
+                          Object {
                             "scale": 0,
                           },
                         ],
@@ -428,6 +431,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                             "position": "absolute",
                             "transform": Array [
                               Object {
+                                "rotate": "0deg",
+                              },
+                              Object {
                                 "scale": 0,
                               },
                             ],
@@ -560,6 +566,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                             "height": 8,
                             "position": "absolute",
                             "transform": Array [
+                              Object {
+                                "rotate": "0deg",
+                              },
                               Object {
                                 "scale": 0,
                               },
@@ -915,6 +924,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                             "position": "absolute",
                             "transform": Array [
                               Object {
+                                "rotate": "0deg",
+                              },
+                              Object {
                                 "scale": 0,
                               },
                             ],
@@ -1135,6 +1147,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                             "position": "absolute",
                             "transform": Array [
                               Object {
+                                "rotate": "0deg",
+                              },
+                              Object {
                                 "scale": 0,
                               },
                             ],
@@ -1325,6 +1340,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                       "position": "absolute",
                       "transform": Array [
                         Object {
+                          "rotate": "0deg",
+                        },
+                        Object {
                           "scale": 0,
                         },
                       ],
@@ -1447,6 +1465,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                       "height": 8,
                       "position": "absolute",
                       "transform": Array [
+                        Object {
+                          "rotate": "0deg",
+                        },
                         Object {
                           "scale": 0,
                         },
@@ -1571,6 +1592,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                       "position": "absolute",
                       "transform": Array [
                         Object {
+                          "rotate": "0deg",
+                        },
+                        Object {
                           "scale": 0,
                         },
                       ],
@@ -1693,6 +1717,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                       "height": 8,
                       "position": "absolute",
                       "transform": Array [
+                        Object {
+                          "rotate": "0deg",
+                        },
                         Object {
                           "scale": 0,
                         },
@@ -1970,6 +1997,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                               "position": "absolute",
                               "transform": Array [
                                 Object {
+                                  "rotate": "0deg",
+                                },
+                                Object {
                                   "scale": 0,
                                 },
                               ],
@@ -2188,6 +2218,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                               "height": 8,
                               "position": "absolute",
                               "transform": Array [
+                                Object {
+                                  "rotate": "0deg",
+                                },
                                 Object {
                                   "scale": 0,
                                 },
@@ -2408,6 +2441,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                               "position": "absolute",
                               "transform": Array [
                                 Object {
+                                  "rotate": "0deg",
+                                },
+                                Object {
                                   "scale": 0,
                                 },
                               ],
@@ -2564,6 +2600,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                           "height": 8,
                           "position": "absolute",
                           "transform": Array [
+                            Object {
+                              "rotate": "0deg",
+                            },
                             Object {
                               "scale": 0,
                             },
@@ -2921,6 +2960,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                                   "position": "absolute",
                                   "transform": Array [
                                     Object {
+                                      "rotate": "0deg",
+                                    },
+                                    Object {
                                       "scale": 0,
                                     },
                                   ],
@@ -3141,6 +3183,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                                   "position": "absolute",
                                   "transform": Array [
                                     Object {
+                                      "rotate": "0deg",
+                                    },
+                                    Object {
                                       "scale": 0,
                                     },
                                   ],
@@ -3360,6 +3405,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                                   "height": 8,
                                   "position": "absolute",
                                   "transform": Array [
+                                    Object {
+                                      "rotate": "0deg",
+                                    },
                                     Object {
                                       "scale": 0,
                                     },
@@ -3639,6 +3687,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                                   "position": "absolute",
                                   "transform": Array [
                                     Object {
+                                      "rotate": "0deg",
+                                    },
+                                    Object {
                                       "scale": 0,
                                     },
                                   ],
@@ -3859,6 +3910,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                                   "position": "absolute",
                                   "transform": Array [
                                     Object {
+                                      "rotate": "0deg",
+                                    },
+                                    Object {
                                       "scale": 0,
                                     },
                                   ],
@@ -4078,6 +4132,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                                   "height": 8,
                                   "position": "absolute",
                                   "transform": Array [
+                                    Object {
+                                      "rotate": "0deg",
+                                    },
                                     Object {
                                       "scale": 0,
                                     },
@@ -4357,6 +4414,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                                   "position": "absolute",
                                   "transform": Array [
                                     Object {
+                                      "rotate": "0deg",
+                                    },
+                                    Object {
                                       "scale": 0,
                                     },
                                   ],
@@ -4576,6 +4636,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                                   "height": 8,
                                   "position": "absolute",
                                   "transform": Array [
+                                    Object {
+                                      "rotate": "0deg",
+                                    },
                                     Object {
                                       "scale": 0,
                                     },
@@ -4798,6 +4861,9 @@ exports[`renders ./components/radio/demo/basic.tsx correctly 1`] = `
                                   "height": 8,
                                   "position": "absolute",
                                   "transform": Array [
+                                    Object {
+                                      "rotate": "0deg",
+                                    },
                                     Object {
                                       "scale": 0,
                                     },

--- a/components/radio/style/index.tsx
+++ b/components/radio/style/index.tsx
@@ -12,14 +12,14 @@ export default (theme: Theme) =>
     checkbox_wave: { borderRadius: 999 },
     checkbox: { borderRadius: 999 },
     checkbox_inner: { width: 0, height: 0 },
-    checkbox_inner_after: {
+    checkbox_inner_before: {
       width: 8,
       height: 8,
       borderRadius: 999,
       backgroundColor: theme.brand_primary,
       borderWidth: 0,
     },
-    checkbox_inner_after_disabled: {
+    checkbox_inner_before_disabled: {
       backgroundColor: '#0003',
     },
     radioItemContent: {


### PR DESCRIPTION
Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

# Fix Checkbox Indeterminate State Error

## Overview

This PR fixes a bug in the checkbox component when using the `indeterminate` property with recent versions of react-native-reanimated.

## Changes Made

- Renamed checkbox inner styles from 'after' to 'before'
- Updated animation logic for checkbox state transitions
- Fixed scale interpolation for indeterminate state

## Related Issue

Fixes issue [#1430](https://github.com/ant-design/ant-design-mobile-rn/issues/1430)

## Testing

Tested with Expo 53 and 52 on iOS and Android devices.


**Note:** This error only occurs in Expo 53 environments.

