### PR TITLE
Fix Issue #1444

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,14 @@ module.exports = {
   rules: {
     'react-native/no-inline-styles': 0,
     semi: [1, 'never'],
-    '@typescript-eslint/no-unused-vars': [1, { args: 'none' }],
+    '@typescript-eslint/no-unused-vars': [
+      1,
+      {
+        args: 'none',
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      },
+    ],
   },
   env: {
     browser: true,

--- a/components/badge/index.tsx
+++ b/components/badge/index.tsx
@@ -35,7 +35,7 @@ export default class Badge extends React.Component<BadgeProps, any> {
       ...restProps // todo: hot
     } = this.props
     return (
-      <WithTheme themeStyles={BadgeStyles} styles={this.props.styles}>
+      <WithTheme themeStyles={BadgeStyles} styles={styles}>
         {(s) => {
           text =
             typeof text === 'number' && text > (overflowCount as number)

--- a/components/list/ListItem.tsx
+++ b/components/list/ListItem.tsx
@@ -159,10 +159,16 @@ const InternalListItem: React.ForwardRefRenderFunction<
       if (typeof extra.props.children === 'function') {
         return <AntmView style={[itemStyles.Extra]}>{extra}</AntmView>
       }
+
+      const viewProps = { ...(extra.props ?? {}) } as Record<string, any>
+      if ('ref' in viewProps) {
+        delete viewProps.ref
+      }
+
       return (
         <AntmView
           children={extra}
-          {...extra.props}
+          {...viewProps}
           style={[itemStyles.Extra, extra.props.style]}
         />
       )

--- a/components/modal/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/modal/__tests__/__snapshots__/demo.test.js.snap
@@ -237,6 +237,7 @@ exports[`renders ./components/modal/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     >

--- a/components/provider/AccessibilityContext.tsx
+++ b/components/provider/AccessibilityContext.tsx
@@ -10,14 +10,15 @@ export interface AccessibilityContextProps {
   children?: React.ReactNode
 }
 
-export const AccessibilityContextProvider: React.FC<AccessibilityContextProps> =
-  ({ children, isRTL }) => {
-    const originValue = React.useContext(AccessibilityContext)
-    return (
-      <AccessibilityContext.Provider value={isRTL ?? originValue}>
-        {children}
-      </AccessibilityContext.Provider>
-    )
-  }
+export const AccessibilityContextProvider: React.FC<
+  AccessibilityContextProps
+> = ({ children, isRTL }) => {
+  const originValue = React.useContext(AccessibilityContext)
+  return (
+    <AccessibilityContext.Provider value={isRTL ?? originValue}>
+      {children}
+    </AccessibilityContext.Provider>
+  )
+}
 
 export default AccessibilityContext

--- a/components/search-bar/index.tsx
+++ b/components/search-bar/index.tsx
@@ -103,10 +103,8 @@ export default class SearchBar extends React.Component<
     const {
       showCancelButton,
       styles,
-      value: propsValue,
       cancelText,
-      onChangeText,
-      onChange,
+      onChange: _,
       disabled,
       style,
       ...restProps

--- a/components/switch/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/switch/__tests__/__snapshots__/demo.test.js.snap
@@ -199,6 +199,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     />
@@ -423,6 +424,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     />
@@ -747,6 +749,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     >
@@ -921,6 +924,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     >
@@ -1108,6 +1112,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     >
@@ -1370,6 +1375,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     />
@@ -1565,6 +1571,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     />
@@ -1790,6 +1797,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     />
@@ -2011,6 +2019,7 @@ exports[`renders ./components/switch/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     />

--- a/components/tabs/Tabs.tsx
+++ b/components/tabs/Tabs.tsx
@@ -304,14 +304,14 @@ export class Tabs extends React.PureComponent<TabsProps, StateType> {
     }
   }
 
-  renderTabBar(tabBarProps: any, DefaultTabBar: React.ComponentClass) {
+  renderTabBar(tabBarProps: any, DefaultTabBarComponent: React.ComponentClass) {
     const { renderTabBar } = this.props
     if (renderTabBar === false) {
       return null
     } else if (renderTabBar) {
       return renderTabBar(tabBarProps)
     } else {
-      return <DefaultTabBar {...tabBarProps} />
+      return <DefaultTabBarComponent {...tabBarProps} />
     }
   }
 

--- a/components/toast/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/toast/__tests__/__snapshots__/demo.test.js.snap
@@ -224,6 +224,7 @@ exports[`renders ./components/toast/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     />
@@ -435,6 +436,7 @@ exports[`renders ./components/toast/demo/basic.tsx correctly 1`] = `
                           "marginLeft": 29,
                           "marginRight": 2,
                           "textAlign": "center",
+                          "zIndex": -1,
                         }
                       }
                     />


### PR DESCRIPTION
* [x] Make sure that you follow antd's [code convention](https://github.com/ant-design/ant-design/wiki/Code-convention-for-antd).
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.


This PR includes 3 commits that address React 19 compatibility, lint issues, and snapshot updates.

## Main Fix

### **🔧 Commit: 4ee9bb76 - "fix: prevent ref prop from being passed to extra component in ListItem"**

**Description:** **This is the main commit that resolves the issue** - Fixed React 19 compatibility issue with ref props.

**Key Changes:**
- In React 19, `ref` is passed as a prop
- Created logic to prevent the `ref` prop from being passed to the `AntmView` component
- **This implementation fixes issue #1444**

## Additional Commits

### 1. Commit: 94be624b - "lint fix"

**Description:** Fixed lint errors found in the codebase.

**Key Changes:**
- Fixed lint errors across the codebase
- Special attention to `search-bar/index.tsx` where unused variables were found:
  - Removed unused variables `Value` and `onChangeText` as they were being overwritten in the code below
  - Used `_` prefix for `onChange` parameter to indicate it's intentionally unused
  - Added necessary ESLint rule to `.eslintrc` configuration to handle this pattern

### 2. Commit: 1fe3369e - "update snapshots"

**Description:** Updated test snapshots to include zIndex changes.

**Key Changes:**
- Updated snapshots to reflect new `zIndex` implementation
- I believe that this implementation was added to fix the issue #1437






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 优化了部分组件的 props 解构和变量命名，提升代码可读性和规范性。
* **修复**
  * 避免无用的 ref 属性传递到视图组件，提升兼容性。
* **其他**
  * 更新了 ESLint 配置，忽略以下划线开头的未使用变量和参数，减少无用警告。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->