### PR TITLE
docs: AGENTS.md teaches npm, but the repo's lockfile is yarn.lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This file provides guidance to AI coding agents when working with code in this r
 ## Environment
 
 - Node.js **22** (see `.nvmrc`). Switch with `fnm use 22` if needed.
-- Root library dev: Node 16.20+ / npm 8.19+.
+- Root library dev: Node 16.20+; package manager: **Yarn** (the repo commits `yarn.lock` and gitignores `package-lock.json`).
 - Expo example: Node **18+** recommended.
 - **Expo HAS CHANGED.** Read the exact versioned docs at https://docs.expo.dev/versions/v54.0.0/ before writing any Expo-related code. The `example/` app uses Expo SDK 54 (`expo@~54.0.33`, React Native 0.81.x).
 
@@ -13,47 +13,47 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ```bash
 # Install dependencies (root)
-npm install
+yarn install
 
 # Lint & typecheck
-npm run lint              # tslint + srclint + applint
-npm run tsc               # TypeScript check (no emit)
+yarn lint                 # tslint + srclint + applint
+yarn tsc                  # TypeScript check (no emit)
 
 # Tests
-npm run test              # Jest
-npm run test:all          # full test suite (pre-publish)
-npm run test -- -u        # update snapshots
-npm run test -- components/button/__tests__/index.test.js -t 'pressIn'  # single test
+yarn test                 # Jest
+yarn test:all             # full test suite (pre-publish)
+yarn test -u              # update snapshots
+yarn test components/button/__tests__/index.test.js -t 'pressIn'  # single test
 
 # Build library (outputs lib/ and es/ — do not edit those by hand)
-npm run compile
-npm run clean
-npm run pub               # publish via antd-tools
+yarn compile
+yarn clean
+yarn pub                  # publish via antd-tools
 
 # Documentation site (dumi)
-npm start                 # dev server on PORT=8003
-npm run deploy            # build + gh-pages
+yarn start                # dev server on PORT=8003
+yarn deploy               # build + gh-pages
 
 # React Native CLI demo (rn-kitchen-sink)
 cd rn-kitchen-sink/ios && pod install   # iOS first time
-npm run ios               # watch-tsc + run-ios
-npm run android           # watch-tsc + run-android
-npm run watch-tsc         # TypeScript watch only
+yarn ios                  # watch-tsc + run-ios
+yarn android              # watch-tsc + run-android
+yarn watch-tsc            # TypeScript watch only
 
 # Expo demo (example/) — preferred for quick component preview
 cd example
 yarn install              # sync peer deps to Expo SDK
-npm start                 # expo start
-npm run ios               # expo start --ios
-npm run android           # expo start --android
-npm run web               # expo start --web
+yarn start                # expo start
+yarn ios                  # expo start --ios
+yarn android              # expo start --android
+yarn web                  # expo start --web
 ```
 
 ## Architecture
 
 ### Monorepo layout
 
-Published npm package: **`@ant-design/react-native`**. Source lives under `components/`; build artifacts go to `lib/` (CJS) and `es/` (ESM). **Never edit `lib/` or `es/` directly** — change `components/` and run `npm run compile`.
+Published npm package: **`@ant-design/react-native`**. Source lives under `components/`; build artifacts go to `lib/` (CJS) and `es/` (ESM). **Never edit `lib/` or `es/` directly** — change `components/` and run `yarn compile`.
 
 ```text
 components/           # All UI components (single source of truth)
@@ -85,7 +85,7 @@ During development, `@ant-design/react-native` resolves to **`components/`**, no
 - **Expo Metro** (`example/metro.config.js`): same alias for the example app
 - **Root Metro** (`metro.config.js`): used by rn-kitchen-sink workflow
 
-After changing components, the Expo app picks up changes via Metro; for the CLI app, `npm run watch-tsc` keeps types in sync.
+After changing components, the Expo app picks up changes via Metro; for the CLI app, `yarn watch-tsc` keeps types in sync.
 
 ### Component conventions
 
@@ -93,7 +93,7 @@ After changing components, the Expo app picks up changes via Metro; for the CLI 
 2. **Naming**: Component folders use **kebab-case** (`date-picker`); implementation files use **`.tsx`**.
 3. **Implementation**: Prefer [react-component](https://github.com/react-component/) where applicable; extract complex logic there when reusable.
 4. **Demos**: Place under `components/<name>/demo/`. Export `title`, `description`, and `demo` for kitchen-sink integration.
-5. **Docs**: Each component has `index.zh-CN.md` / `index.en-US.md` beside the source; rendered by **dumi** (`npm start`).
+5. **Docs**: Each component has `index.zh-CN.md` / `index.en-US.md` beside the source; rendered by **dumi** (`yarn start`).
 6. **Platform**: Generally no Android/iOS file suffix unless platform-specific behavior is required (see `components/input/TextArea/` for an exception).
 
 ### Key dependencies
@@ -112,7 +112,7 @@ Install peers in Expo apps with `npx expo install <package>` so versions match t
 1. Implement in `components/<component-name>/` (index, style, PropsType as needed).
 2. Export from `components/index.tsx`.
 3. Add `demo/basic.tsx` (and `.md` if needed for dumi).
-4. Add `__tests__/` with Jest; run `npm run test`.
+4. Add `__tests__/` with Jest; run `yarn test`.
 5. Register in **`rn-kitchen-sink/demoList.js`** and ensure `./index.js` exports if required (CLI demo).
 6. For Expo demo routes, add under `example/app/` as needed (expo-router file-based routing).
 7. Add or update `index.zh-CN.md` / `index.en-US.md` documentation.
@@ -120,7 +120,7 @@ Install peers in Expo apps with `npx expo install <package>` so versions match t
 ## Pull requests
 
 - Branch from `master`: `git checkout -b xx-feature`
-- Run `npm run lint` and `npm run test:all` before submitting
+- Run `yarn lint` and `yarn test:all` before submitting
 - Rebase on `master` before push; open PR and request review
 
 ## References


### PR DESCRIPTION
> 中文摘要：AGENTS.md 里所有根目录命令都写的是 `npm install` / `npm run <script>`，但仓库唯一提交的 lockfile 是 `yarn.lock`，且 `.gitignore` 明确忽略 `package-lock.json`——按文档执行 `npm install` 会完全绕过 lockfile 的版本锁定。本 PR 把 AGENTS.md 根目录命令统一改为 yarn 形式，纯文档改动。

## What & why

`AGENTS.md` (which `CLAUDE.md` `@`-imports, so it's what Claude Code / Cursor / Codex actually read) teaches `npm install` / `npm run <script>` for every root-level workflow. But the repo's dependency ground truth is Yarn:

- The only committed lockfile is `yarn.lock`; `package-lock.json` is explicitly listed in `.gitignore`.
- So an agent (or contributor) following AGENTS.md runs `npm install`, which **ignores `yarn.lock`'s pinned resolutions entirely** and produces a lockfile git throws away — an unpinned, silently divergent dependency tree, with nothing failing loudly enough to notice.

This PR switches the root-scope commands in AGENTS.md to their yarn form (`yarn install` / `yarn lint` / `yarn test` / `yarn compile` / …), including the "Pull requests" checklist at the bottom, and names Yarn as the package manager on the environment line that previously said "npm 8.19+". The `example/` Expo block already began with `yarn install`; its remaining `npm start` / `npm run ios` lines were normalized to match. `npx expo install <package>` is deliberately untouched — that's the standard Expo idiom regardless of package manager.

Docs-only, 1 file, 25 lines. Happy to downscope (e.g. just the install command) if you'd prefer.

**Full disclosure:** we found this while validating [ai-harness-doctor](https://github.com/NieZhuZhu/ai-harness-doctor), a docs-vs-lockfile drift linter we maintain — that's how this repo ended up in our scan sample. The claim above is verifiable straight from `.gitignore` + `yarn.lock`, no tool required. For what the defect class costs in practice: on another repo with the same disease (agent docs teaching the wrong package manager), command questions failed deterministically — the agent echoed the stale doc line verbatim in every run — until the doc was fixed ([measurement & methodology](https://github.com/NieZhuZhu/ai-harness-doctor/tree/main/benchmark/corpus/evals/comp)).

## Checklist

* [x] antd code convention — N/A, markdown-only change, no code touched.
* [x] Lint — N/A for a docs-only change (no lintable source modified).
* [x] Rebased on today's `master` tip (ebf8a8d) before opening the PR.
* [x] Description above; no linked issue — happy to open a tracking issue if you prefer.

P.S. Two adjacent observations, deliberately left out of scope to keep this PR mechanical: (1) `development.en-US.md` / `development.zh-CN.md` teach the same `npm install` flow to humans — the same substitution applies there if you want it; (2) AGENTS.md line 7 says Node **22** (matching `.nvmrc`) while line 8 says "Node 16.20+" — the two read as contradicting each other, and I only touched the package-manager half of that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新开发者指南中的开发、构建、测试、文档站点及示例启动命令，统一使用 Yarn。
  * 调整组件开发、代码同步与 Pull Request 流程中的命令说明。
  * 补充 Yarn 相关的项目开发与包管理约定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->